### PR TITLE
Reset points in pointbox on next page

### DIFF
--- a/components/pointsbox.tsx
+++ b/components/pointsbox.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react';
 import Select from 'react-select';
+import type { Option } from './textbox'
 
-interface Option {
-  value: number;
-  label: string;
-}
 
 interface Pointsboxprop {
-  maxPoints: number
+    maxPoints: number;
+    selectedOption: Option | null | undefined;
+    setSelectedOption: any;
 }
-
 
 const Pointsbox: React.FC<Pointsboxprop> = (props: Pointsboxprop) => {
   const options: Option[] = [];
@@ -19,22 +17,21 @@ const Pointsbox: React.FC<Pointsboxprop> = (props: Pointsboxprop) => {
     options.push({value: i, label: i.toString() + ' p'})
   }
   
-  const [selectedOption, setSelectedOption] = useState<Option | null>();
 
 
   return (
       <div>
         <Select
           instanceId='long-value-select' //react select component needs an id 
-          defaultValue={selectedOption}
-          onChange={setSelectedOption}
+          defaultValue={props.selectedOption}
+          onChange={props.setSelectedOption}
           options={options}
           isClearable={true}
           isSearchable={false} 
         />
       </div>
   );
-}
+};
 
 export default Pointsbox;
 

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -1,16 +1,28 @@
 import * as React from 'react';
 import styles from "../styles/Textbox.module.css";
 import Pointsbox from "./pointsbox";
+import {useState} from "react";
 
-interface textboxprop {
-    text: string,
-    maxPoints: number
+
+export interface Option {
+    value: number;
+    label: string;
 }
-const Textbox = (props: textboxprop) => {
+interface textboxprop {
+    text: string;
+    maxPoints: number;
+}
+
+const Textbox: React.FC<textboxprop> = (props: textboxprop) => {
+    const [selectedOption, setSelectedOption] = useState<Option | null | undefined>();
     return (
         <div className={styles.card}>
             <div className={styles.alignTitlePoints}>
-                <Pointsbox maxPoints={props.maxPoints}/>
+                <Pointsbox
+                    maxPoints={props.maxPoints}
+                    selectedOption={selectedOption}
+                    setSelectedOption={setSelectedOption}
+                />
             </div>
             {props.text}
         </div>

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -31,7 +31,7 @@ const Assessment: NextPage = () => {
     } else if (direction == 'next') {
       setCurrentPage(currentPage + 1)
     }
-  }
+  };
 
   return (
     <div className={styles.container}>
@@ -40,7 +40,8 @@ const Assessment: NextPage = () => {
         </h1>
       <main className={styles.main}>
           <div className={styles.grid}>
-            {answers.slice((currentPage * maxItemsPerPage) - maxItemsPerPage, currentPage * maxItemsPerPage ).map((answer: string) => <Textbox text={answer} maxPoints={5}/>)}          
+            {answers.slice((currentPage * maxItemsPerPage) - maxItemsPerPage, currentPage * maxItemsPerPage ).map(
+                (answer: string) => <Textbox key={answer} text={answer} maxPoints={5}/>)}
           </div>
           <div className={styles.next}/>
       </main>
@@ -56,6 +57,6 @@ const Assessment: NextPage = () => {
       </footer>
     </div>
   )
-}
+};
 
 export default Assessment


### PR DESCRIPTION
We moved the state up to textbox. Don't understand why it works.
So we pushed it to check it on @sylvihuynh 's computer.

If it doesn't work:
Try `useEffect()` around the generating of options that watches (read: with dependancy) `currentPage`.