### PR TITLE
change props in expand, add display cond for answ

### DIFF
--- a/components/expand.tsx
+++ b/components/expand.tsx
@@ -5,18 +5,18 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import {ExpandMore as ExpandMoreIcon} from '@material-ui/icons';
 
 interface Expandprop {
-  taskDescriptionTitle: string;
-  taskDescription: string;
+  DescriptionTitle: string;
+  Description: string;
 }
 
 
 const Expand: React.FC<Expandprop> = (props: Expandprop) => {
    
     return (
-        <div>
+        <div style={{ margin: "1rem"}}>
       <Accordion
         sx={{
-          width: 400,
+          width: 600,
           boxShadow: "none",
         }}>
         <AccordionSummary
@@ -24,10 +24,10 @@ const Expand: React.FC<Expandprop> = (props: Expandprop) => {
           aria-controls="task-content" // For optimal accessibility it is recommended setting id and aria-controls on the AccordionSummary. 
           id="task-header"// The Accordion will derive the necessary aria-labelledby and id for the content region of the accordion.
         >
-          <strong>{props.taskDescriptionTitle}</strong>
+          <strong>{props.DescriptionTitle}</strong>
         </AccordionSummary>
         <AccordionDetails>
-          {props.taskDescription}  
+          {props.Description}  
         </AccordionDetails>
       </Accordion>
     </div>

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -11,15 +11,18 @@ import {Button} from "@mui/material";
 import Header from "../components/header";
 
 
+
 const Assessment: NextPage = () => {
   const taskNumber: number = 2; // Later will get it another way. And then make sure tasknumber doesn't get too high.
 
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [maxItemsPerPage, setMaxItemsPerPage] = useState<number>(4); //max items set to 4 as default
 
-  const taskDescription: string = 'Variabler med nøkkelordet var er globale, mens varibler med nøkkelordet let har et local scope eller blokk scope som vil si at de kun defineres for deler av koden om de defineres inni en kodeblokk.'
+
   const answers: TextboxDataType[] = insperaDataToTextboxObject(data, taskNumber);
   const maxPoints: number = data.ext_inspera_candidates[0].result.ext_inspera_questions[0].ext_inspera_maxQuestionScore;
+  const taskDescription: string = 'Variabler med nøkkelordet var er globale, mens varibler med nøkkelordet let har et local scope eller blokk scope som vil si at de kun defineres for deler av koden om de defineres inni en kodeblokk.'  
+  const markersGuideDescription: string = 'let - block scope. Dersom variabelen blir deklarert med let i en funksjon, er den bare tilgjengelig i funksjonen. var - global scope Dersom variabelen blir deklarert med var, blir den tilgjengelig i all kode. Kan by på problemer når vi gir variabler samme navn.'
 
   const changePage = (direction: string) : void => {
     if (direction == 'back') {
@@ -34,17 +37,33 @@ const Assessment: NextPage = () => {
     <div className={styles.container}>
       <Header data={data} taskNumber={taskNumber}/>
       <main className={styles.main}>
-        <Expand 
-          taskDescriptionTitle='User interfaces' 
-          taskDescription={taskDescription}>
-        </Expand>
-          <div className={styles.grid}>
+        <div className={styles.grid}>
+          <Expand 
+            DescriptionTitle='User interfaces' 
+            Description={taskDescription}>
+          </Expand>
+          <Expand 
+            DescriptionTitle="Marker's guide" 
+            Description={markersGuideDescription}>
+          </Expand>
+        </div>
+
+        {/* Display two answers next to eachother when max items is four or less  */}
+        {maxItemsPerPage<=4 ? 
+          <div className={styles.grid4answers}>
             {answers.slice((currentPage * maxItemsPerPage) - maxItemsPerPage, currentPage * maxItemsPerPage ).map(
-                (answer: TextboxDataType) => <Textbox key={answer.answerId} text={answer.answer} maxPoints={maxPoints}/>
+              (answer: TextboxDataType) => <Textbox key={answer.answerId} text={answer.answer} maxPoints={maxPoints}/>
                 )}
+            </div>
+        :  <div className={styles.grid}>
+            {answers.slice((currentPage * maxItemsPerPage) - maxItemsPerPage, currentPage * maxItemsPerPage ).map(
+              (answer: TextboxDataType) => <Textbox key={answer.answerId} text={answer.answer} maxPoints={maxPoints}/>
+              )}
           </div>
+        }
       </main>
-      <div className={styles.footer}>
+
+      <div className={styles.footer}> 
         {currentPage > 1? 
           <div className={styles.leftArrow} onClick={() => changePage('back')}></div>
         : null}

--- a/styles/assessment.module.css
+++ b/styles/assessment.module.css
@@ -7,13 +7,14 @@
 }
 
 
-
 .main { 
   flex: 1;  
   display: flex;
   flex-direction: column;
   align-items: center;
 }
+
+
 
 .footer {
   width: 100%;
@@ -24,13 +25,18 @@
 }
 
 
-.grid {
+.grid,
+.grid4answers {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   flex-wrap: wrap;
+  
+}
+.grid4answers{
   max-width: 115em;
 }
+
 
 .rightArrow {
   border: solid #7E9AA3;
@@ -40,8 +46,8 @@
   transform: rotate(-45deg);
   -webkit-transform: rotate(-45deg);
   cursor: pointer;
-
 }
+
 .rightArrow:hover {
   border: solid #A7C4CD;
   border-width: 0 5px 5px 0;
@@ -55,8 +61,8 @@
   transform: rotate(135deg);
   -webkit-transform: rotate(135deg);
   cursor: pointer;
-
 }
+
 .leftArrow:hover {
   border: solid #A7C4CD;
   border-width: 0 5px 5px 0;


### PR DESCRIPTION
- create place for marker's guidance on line with the task description accordion
- handle styling when maxItemsPerPage is four or less making the page display two answer horizontally next to each other

