### PR TITLE
Display all answers and points given on approval page

### DIFF
--- a/components/approvalTextbox.tsx
+++ b/components/approvalTextbox.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { approvaltextboxprop } from '../types/Types';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+
+const ApprovalTextbox: React.FC<approvaltextboxprop> = (props: approvaltextboxprop) => {
+  return (
+      <Paper sx={{ p: 3, margin: 'auto', width: 800 }}>
+        <Grid container spacing={2}>
+          <Grid item>
+            <Typography  variant="subtitle1" component="div">
+              {props.candidateId}
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sm container sx={{ mt: 0.5 }}>
+            <Typography variant="body2" gutterBottom>
+              {props.answer}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Typography  variant="subtitle1" component="div">
+              {props.points}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Paper>
+  );
+};
+
+export default ApprovalTextbox;

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -39,7 +39,7 @@ const Approval: NextPage = () => {
         {data.ext_inspera_assessmentRunTitle}
       </h1>
       <main className={styles.main}>
-        <Grid container gap={2}>
+        <Grid container gap={2} xs={5}>
         {answers.map((answer: approvaltextboxprop) => <ApprovalTextbox
           key={answer.answerId}
           candidateId={answer.candidateId}

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -39,7 +39,7 @@ const Approval: NextPage = () => {
         {data.ext_inspera_assessmentRunTitle}
       </h1>
       <main className={styles.main}>
-        <Grid container gap={2} xs={5}>
+        <Grid container gap={2} xs={5} item={true}>
         {answers.map((answer: approvaltextboxprop) => <ApprovalTextbox
           key={answer.answerId}
           candidateId={answer.candidateId}

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -1,11 +1,37 @@
 import { NextPage } from 'next'
-import styles from '../styles/assessment.module.css'
+import styles from '../styles/approval.module.css'
 import data from '../data/IT2810Høst2018.json'
 import Link from "next/link";
 import {Button} from "@mui/material";
+import Grid from '@mui/material/Grid';
+import ApprovalTextbox from "../components/approvalTextbox";
+import { approvaltextboxprop } from '../types/Types';
+import * as React from "react";
 
 
 const Approval: NextPage = () => {
+  const answers: approvaltextboxprop[] = [
+    { answerId: '1006_23424',
+      candidateId: '1006',
+      answer: 'This is my answer',
+      points: '1 p'
+    },
+    { answerId: '1007_23424',
+      candidateId: '1007',
+      answer: 'This is my answer',
+      points: '0 p'
+    },
+    { answerId: '1016_23424',
+      candidateId: '1016',
+      answer: 'This is my very very long answer as an example for this since we need to check how it works with lots of text',
+      points: '2 p'
+    },
+    { answerId: '1254_23424',
+      candidateId: '1254',
+      answer: 'This is my answer',
+      points: '4 p'
+    },
+  ];
 
   return (
     <div className={styles.container}>
@@ -13,11 +39,21 @@ const Approval: NextPage = () => {
         {data.ext_inspera_assessmentRunTitle}
       </h1>
       <main className={styles.main}>
-        <Link href="/assessment">
-          <Button variant="contained">
-            Back
-          </Button>
-        </Link>
+        <Grid container gap={2}>
+        {answers.map((answer: approvaltextboxprop) => <ApprovalTextbox
+          key={answer.answerId}
+          candidateId={answer.candidateId}
+          answer={answer.answer}
+          points={answer.points}
+          answerId={''} />)}
+        </Grid>
+        <div style={{padding: 20}}>
+          <Link  href="/assessment">
+            <Button  variant="contained">
+              Back
+            </Button>
+          </Link>
+        </div>
       </main>
     </div>
   )

--- a/styles/Approval.module.css
+++ b/styles/Approval.module.css
@@ -1,0 +1,15 @@
+.container {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: rgb(240, 250, 255);
+}
+
+.main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+

--- a/types/Types.tsx
+++ b/types/Types.tsx
@@ -3,3 +3,10 @@ export interface TextboxDataType {
     answer: string | undefined;
     candidateId: number;
 }
+
+export interface approvaltextboxprop {
+    answerId: string;
+    candidateId: string;
+    answer: string;
+    points: string;
+}


### PR DESCRIPTION
The approval page now shows all of the given candidates with their
points on the current task.
As of now, there is example-data displayed, but it should be okay to
swap later.