### PR TITLE
Replace react-select with MUI

### DIFF
--- a/components/pointsbox.tsx
+++ b/components/pointsbox.tsx
@@ -1,6 +1,10 @@
 import React from "react";
-import Select from "react-select";
 import { AssessmentType } from "../types/Types";
+import Box from '@mui/material/Box';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
 
 interface Option {
   value: number;
@@ -13,29 +17,46 @@ interface Pointsboxprop {
 }
 
 const Pointsbox: React.FC<Pointsboxprop> = (props: Pointsboxprop) => {
-  const options: Option[] = [{ value: 0, label: "0 p" }];
+  const [open, setOpen] = React.useState(false);
 
-  // add option objects to option list
-  for (let i = 1; i < props.assessment.maxPoints + 1; i++) {
+  const options: Option[] = [{ value: 0, label: "0 p" }];
+  for (let i = 1; i < props.assessment.maxPoints + 1; i++) { // add option objects to option list
     options.push({ value: i, label: i.toString() + " p" });
   }
 
-  const handleChange = (selectedOption: Option) => {
-    props.setAssessment(props.assessment, selectedOption.value);
+  const handleChange = (selectedOption: any) => {
+    props.setAssessment(props.assessment, selectedOption.target.value)
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleOpen = () => {
+    setOpen(true);
   };
 
   return (
-    <div>
-      <Select
-        instanceId="long-value-select"
-        defaultValue={props.assessment.score}
-        onChange={handleChange}
-        options={options}
-        isClearable={true}
-        isSearchable={false}
-        placeholder="Sett poeng"
-      />
-    </div>
+      <Box sx={{ minWidth: 120 }}>
+        <FormControl sx={{ m: 1, minWidth: 130 }}>
+          <InputLabel id="demo-simple-select-label">Sett poeng</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            open={open}
+            onClose={handleClose}
+            onOpen={handleOpen}
+            value={props.assessment.score}
+            label="Sett poeng"
+            onChange={handleChange}
+          >
+            <MenuItem value="">
+              <em>Sett poeng</em>
+            </MenuItem>
+            {options.map((option: Option) => <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>)}
+          </Select>
+        </FormControl>
+      </Box>
   );
 };
 

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -48,7 +48,7 @@ const Assessment: NextPage = () => {
 
   const answers: AnswerType[] = insperaDataToTextboxObject(data, taskNumber);
   sortAnswers(answers, "length_hl");
-  const p = answers.map((answer: AnswerType) => ({ score: null, ...answer }));
+  const p = answers.map((answer: AnswerType) => ({ score: "", ...answer }));
   const [assessments, setAssessments] = useState<AssessmentType[]>(p);
   const [reAssessments, setReAssessments] = useState<AssessmentType[]>([]);
 
@@ -83,7 +83,7 @@ const Assessment: NextPage = () => {
     }
   };
 
-  const setAssessment = (assessment: AssessmentType, newScore: number) => {
+  const setAssessment = (assessment: AssessmentType, newScore: number | string) => {
     const newAssessment = {
       ...assessment,
       score: newScore,

--- a/types/Types.tsx
+++ b/types/Types.tsx
@@ -11,7 +11,7 @@ export interface AssessmentType {
   candidateId: number;
   taskNumber: number;
   maxPoints: number;
-  score: number | null;
+  score: number | string;
 }
 
 export interface AnswerType {


### PR DESCRIPTION
fix #68 
We had a seemingly unsolvable problem with the Option-type to react-select. Here the react-select component is replaced with a Material UI component (which is what we use everywhere else as well).
It is also smaller and nicer pointbox.

Work that still need to be done:
* Apply state when moving back in the answers
* Apply state (from local storage) when revisiting the page