### PR TITLE
Swap course and tasktitle in the header

### DIFF
--- a/components/expand.tsx
+++ b/components/expand.tsx
@@ -5,7 +5,6 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 import { ExpandMore as ExpandMoreIcon } from "@material-ui/icons";
 
 interface Expandprop {
-  PreDescription?: string;
   DescriptionTitle: string;
   Description: string;
 }
@@ -24,7 +23,6 @@ const Expand: React.FC<Expandprop> = (props: Expandprop) => {
           aria-controls="task-content" // For optimal accessibility it is recommended setting id and aria-controls on the AccordionSummary.
           id="task-header" // The Accordion will derive the necessary aria-labelledby and id for the content region of the accordion.
         >
-          {props.PreDescription ? props.PreDescription + ":" : null}
           <strong>{props.DescriptionTitle}</strong>
         </AccordionSummary>
         <AccordionDetails>{props.Description}</AccordionDetails>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,18 +4,20 @@ import Link from "next/link";
 
 interface Headerprops {
   data: any;
-  taskNumber: number;
+  taskNumber?: number;
   description?: string;
 }
 
 const Header: React.FC<Headerprops> = (props: Headerprops) => {
   return (
     <div className={styles.headerstyle}>
-      {props.description ? (
+      {props.taskNumber && props.description ? (
         <h1>
-          Oppgave {props.taskNumber}: {props.description}
+          Oppgave {props.taskNumber} : {props.description}
         </h1>
-      ) : null}
+      ) : (
+        <h1>{props.description}</h1>
+      )}
       <Link href="/">
         <h2 className={styles.makeClickable}>
           {props.data.ext_inspera_assessmentRunTitle}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,18 +4,23 @@ import Link from "next/link";
 
 interface Headerprops {
   data: any;
+  taskNumber: number;
   description?: string;
 }
 
 const Header: React.FC<Headerprops> = (props: Headerprops) => {
   return (
     <div className={styles.headerstyle}>
-      <Link href="/">
-        <h1 className={styles.makeClickable}>
-          {props.data.ext_inspera_assessmentRunTitle}
+      {props.description ? (
+        <h1>
+          Oppgave {props.taskNumber}: {props.description}
         </h1>
+      ) : null}
+      <Link href="/">
+        <h2 className={styles.makeClickable}>
+          {props.data.ext_inspera_assessmentRunTitle}
+        </h2>
       </Link>
-      {props.description ? <h2>{props.description}</h2> : null}
     </div>
   );
 };

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -105,13 +105,12 @@ const Assessment: NextPage = () => {
 
   return (
     <div className={styles.container}>
-      <Header data={data} />
+      <Header data={data} taskNumber={taskNumber} description={taskTitle} />
       <main className={styles.main}>
         <div className={styles.alignInfo}>
           <div className={styles.expandInfo}>
             <Expand
-              PreDescription={"Oppgave " + taskNumber}
-              DescriptionTitle={taskTitle}
+              DescriptionTitle="Oppgavebeskrivelse"
               Description={taskDescription}
             />
             <Expand


### PR DESCRIPTION
fix #59 

- Swap course and task title in the header
- Add tasknumber to the header
- Change from tasktitle as description in the expand infobox to "Oppgavebeskrivelse"