### PR TITLE
Save assessments to localstorage

### DIFF
--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -85,6 +85,17 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
     // add assessments from batch to assessments list locally
     batch.map((assessment) => {
       if (assessment.score != null) {
+        // check if the assessment is already evaluated
+        if (
+          assessments.filter(function (a) {
+            return a.assessmentId === assessment.assessmentId;
+          }).length > 0
+        ) {
+          //remove existing assessment
+          assessments = assessments.filter(
+            (a) => a.assessmentId != assessment.assessmentId
+          );
+        }
         assessments.push(assessment);
       }
     });

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -71,25 +71,22 @@ export function saveAssessments(
 ): void {
   // local storage is a property of object window. Accessing localStroage is not possible until React component has mounted
   if (typeof window !== "undefined") {
-    {
-      /*might need similiar code later, therefore kept but commented out*/
-    }
-
-    //  // retrieve data from localStorage and convert it to array
-    // let candidateAssessments: AssessmentType[] =
-    //   JSON.parse(localStorage.getItem(key.toString()) as string) || [];
-    // console.log(candidateAssessments);
-
-    //  // create new object
-    //   let newAssessment: AssessmentType[] = {
-    //       'taskNumber': taskNumber,
-    //       'points': points
-    //   }
-
-    //   // add new object to array of assessments locally
-    //   candidateAssessments.push(assessments)
-
     // store array as a string
+    localStorage.setItem(key.toString(), JSON.stringify(assessments));
+  }
+}
+
+export function saveBatch(batch: AssessmentType[], taskNumber: number) {
+  const key = taskNumber.toString() + "_assessments";
+  if (typeof window !== "undefined") {
+    let assessments: AssessmentType[] =
+      JSON.parse(localStorage.getItem(key) as string) || [];
+
+    // add assessments from batch to assessments list locally
+    batch.map((assessment) => {
+      assessments.push(assessment);
+    });
+
     localStorage.setItem(key.toString(), JSON.stringify(assessments));
   }
 }

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -84,7 +84,7 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
 
     // add assessments from batch to assessments list locally
     batch.map((assessment) => {
-      if (assessment.score != "") {
+      if (assessment.score !== "") {
         // check if the assessment is already evaluated
         if (
           assessments.filter(function (a) {
@@ -97,6 +97,10 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
           );
         }
         assessments.push(assessment);
+      } else {
+        assessments = assessments.filter(
+          (a) => a.assessmentId != assessment.assessmentId
+        );
       }
     });
 

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -84,7 +84,7 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
 
     // add assessments from batch to assessments list locally
     batch.map((assessment) => {
-      if (assessment.score != null) {
+      if (assessment.score != "") {
         // check if the assessment is already evaluated
         if (
           assessments.filter(function (a) {

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -84,7 +84,9 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
 
     // add assessments from batch to assessments list locally
     batch.map((assessment) => {
-      assessments.push(assessment);
+      if (assessment.score != null) {
+        assessments.push(assessment);
+      }
     });
 
     localStorage.setItem(key.toString(), JSON.stringify(assessments));

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -100,7 +100,7 @@ export function saveBatch(batch: AssessmentType[], taskNumber: number) {
       }
     });
 
-    localStorage.setItem(key.toString(), JSON.stringify(assessments));
+    localStorage.setItem(key, JSON.stringify(assessments));
   }
 }
 
@@ -111,50 +111,77 @@ export function clearLocalStorage(): void {
 }
 
 // b = true will return outliers among those score with a high freq
-export function chooseFrequentAssessmentBasedOnScore(assessments : AssessmentType[], isHighFrequency : boolean) {
-  const numberOfAGivenScore = Array.from({length: assessments[0].maxPoints+1}, () => 0); // number of times x points are given, points = index
-  var hasNullScore = false;                      
+export function chooseFrequentAssessmentBasedOnScore(
+  assessments: AssessmentType[],
+  isHighFrequency: boolean
+) {
+  const numberOfAGivenScore = Array.from(
+    { length: assessments[0].maxPoints + 1 },
+    () => 0
+  ); // number of times x points are given, points = index
+  var hasNullScore = false;
   assessments.map((assessment) => {
-    assessment.score == null ? hasNullScore = true :
-    numberOfAGivenScore[assessment.score] += 1
+    assessment.score == null
+      ? (hasNullScore = true)
+      : (numberOfAGivenScore[assessment.score] += 1);
   });
 
-  var n : number;
+  var n: number;
   if (isHighFrequency) {
-    n = Math.max(...numberOfAGivenScore); 
+    n = Math.max(...numberOfAGivenScore);
   } else {
-    const reducedNumberOfAGivenScore = numberOfAGivenScore.filter(n => n <= 0);
+    const reducedNumberOfAGivenScore = numberOfAGivenScore.filter(
+      (n) => n <= 0
+    );
     n = Math.min(...reducedNumberOfAGivenScore);
   }
-    const res : number[] = [];
-    numberOfAGivenScore.forEach((item, index) => item === n ? res.push(index): null);
+  const res: number[] = [];
+  numberOfAGivenScore.forEach((item, index) =>
+    item === n ? res.push(index) : null
+  );
 
-    const score = res[Math.floor(Math.random() * res.length)];
-    const outlierAssessments =  assessments.filter(assessment => assessment.score == score);
+  const score = res[Math.floor(Math.random() * res.length)];
+  const outlierAssessments = assessments.filter(
+    (assessment) => assessment.score == score
+  );
 }
 
 // Returns only 1 answer so it is not overwhelming
 // To unveil bias towards longer answers
-export function chooseCorrelatedAssessment(assessments: AssessmentType[]) : AssessmentType | null {
-  const maxPoints = assessments[0].maxPoints
-  const allScores = Array.from({length: maxPoints+1}, (v, i) => i)   // if len=5, gives [0, 1, 2, 3, 4]
+export function chooseCorrelatedAssessment(
+  assessments: AssessmentType[]
+): AssessmentType | null {
+  const maxPoints = assessments[0].maxPoints;
+  const allScores = Array.from({ length: maxPoints + 1 }, (v, i) => i); // if len=5, gives [0, 1, 2, 3, 4]
   // Get the top scores ranging from 0.75*maxpoints to maxpoints
-  const topScores: number[] = allScores.slice(-(Math.floor((maxPoints*0.25))+1)) // The +1 is to get the number on the right index 
-  
-  const noNullScoreAssessments = assessments.filter(a => a.score != null);
-  const topScoreAssessments = noNullScoreAssessments.filter(assessment =>  topScores.includes(assessment.score));
+  const topScores: number[] = allScores.slice(
+    -(Math.floor(maxPoints * 0.25) + 1)
+  ); // The +1 is to get the number on the right index
+
+  const noNullScoreAssessments = assessments.filter((a) => a.score != null);
+  const topScoreAssessments = noNullScoreAssessments.filter((assessment) =>
+    topScores.includes(assessment.score)
+  );
 
   var lengthLongestAnswer = 0;
-  assessments.map(a => a.answer.length > lengthLongestAnswer ? lengthLongestAnswer = a.answer.length : null); // tror man kan bruke reduce elns i stedet
-  var longAnswerAssessments: AssessmentType[] = assessments.filter((v) => v.answer.length >= 0.75*lengthLongestAnswer)
+  assessments.map((a) =>
+    a.answer.length > lengthLongestAnswer
+      ? (lengthLongestAnswer = a.answer.length)
+      : null
+  ); // tror man kan bruke reduce elns i stedet
+  var longAnswerAssessments: AssessmentType[] = assessments.filter(
+    (v) => v.answer.length >= 0.75 * lengthLongestAnswer
+  );
 
   // Get the answers that are longest and has a top score
-  const correlatedAssessments: AssessmentType[] = longAnswerAssessments.filter(a => topScoreAssessments.includes(a))
+  const correlatedAssessments: AssessmentType[] = longAnswerAssessments.filter(
+    (a) => topScoreAssessments.includes(a)
+  );
 
- // Choose one answer to return
+  // Choose one answer to return
   if (correlatedAssessments.length >= 1) {
-    const index = Math.floor(Math.random() * (correlatedAssessments.length))
-    return correlatedAssessments[index]
-  }  
-  return null
+    const index = Math.floor(Math.random() * correlatedAssessments.length);
+    return correlatedAssessments[index];
+  }
+  return null;
 }

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import data from "../data/IT2810Høst2018.json";
 import Expand from "../components/expand";
 import {
+  clearLocalStorage,
   insperaDataToTextboxObject,
   chooseCorrelatedAssessment,
   saveAssessments,

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -8,6 +8,7 @@ import {
   insperaDataToTextboxObject,
   chooseCorrelatedAssessment,
   saveAssessments,
+  saveBatch,
 } from "../functions/helpFunctions";
 import { sortAnswers } from "../functions/sortAlgorithms";
 import { AssessmentType, AnswerType } from "../types/Types";
@@ -66,6 +67,7 @@ const Assessment: NextPage = () => {
     } else if (direction == "next") {
       appendReAssessments(assessments.slice(startIndexBatch, endIndexBatch));
       setCurrentPage(currentPage + 1);
+      saveBatch(assessments.slice(startIndexBatch, endIndexBatch), taskNumber);
     }
   };
 

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -67,8 +67,8 @@ const Assessment: NextPage = () => {
       setCurrentPage(currentPage - 1);
     } else if (direction == "next") {
       appendReAssessments(assessments.slice(startIndexBatch, endIndexBatch));
-      setCurrentPage(currentPage + 1);
       saveBatch(assessments.slice(startIndexBatch, endIndexBatch), taskNumber);
+      setCurrentPage(currentPage + 1);
     }
   };
 

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import data from "../data/IT2810Høst2018.json";
 import Expand from "../components/expand";
 import {
-  clearLocalStorage,
   insperaDataToTextboxObject,
   chooseCorrelatedAssessment,
   saveAssessments,


### PR DESCRIPTION
fix #67 

Save current batch to localstorage when next is clicked. Only assessments that have a score will be saved. The batches are saved on key taskNumber_assessments, ex. 2_assessments. 


There is a problem with overwriting earlier assessments due to new ids being generated each time we refresh/go back and forth to the assessment pages. Meaning that the "same" assessment might be added to localstorage several times. 
