### PR TITLE
32 format answers

### DIFF
--- a/components/approvalTextbox.tsx
+++ b/components/approvalTextbox.tsx
@@ -3,6 +3,7 @@ import { AssessmentType } from "../types/Types";
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
+import parse from "html-react-parser";
 
 const ApprovalTextbox: React.FC<AssessmentType> = (
   assessment: AssessmentType
@@ -17,11 +18,16 @@ const ApprovalTextbox: React.FC<AssessmentType> = (
         </Grid>
         <Grid item xs={12} sm container sx={{ mt: 0.5 }}>
           <Typography variant="body2" gutterBottom>
-            {assessment.answer}
+            {parse(assessment.answer)}
           </Typography>
         </Grid>
         <Grid item>
-          <Typography variant="subtitle1" align="center" component="div" sx={{ width: 40 }}>
+          <Typography
+            variant="subtitle1"
+            align="center"
+            component="div"
+            sx={{ width: 40 }}
+          >
             {assessment.score} p
           </Typography>
         </Grid>

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -19,8 +19,7 @@ const Textbox: React.FC<textboxprop> = (props: textboxprop) => {
           setAssessment={props.setAssessment}
         />
       </div>
-      <div className={styles.scrollable}>{props.assessment.answer}</div>
-      {parse(props.assessment.answer)}
+      <div className={styles.scrollable}>{parse(props.assessment.answer)}</div>
     </div>
   );
 };

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import styles from "../styles/Textbox.module.css";
 import Pointsbox from "./pointsbox";
 import { AssessmentType } from "../types/Types";
+import parse from "html-react-parser";
 
 interface textboxprop {
   assessment: AssessmentType;
@@ -19,6 +20,7 @@ const Textbox: React.FC<textboxprop> = (props: textboxprop) => {
         />
       </div>
       <div className={styles.scrollable}>{props.assessment.answer}</div>
+      {parse(props.assessment.answer)}
     </div>
   );
 };

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -5,24 +5,26 @@ function cleanHtmlText(content: string) {
   if (content == undefined) {
     return "";
   }
-  var cleanHtml = removeHtmlTags(content);
-  var cleanHtml = cleanHtml.replace(/&#160;/g, " ");
-  var cleanHtml = cleanHtml.replace(/&#230;/g, "æ");
-  var cleanHtml = cleanHtml.replace(/&#248;/g, "ø");
-  var cleanHtml = cleanHtml.replace(/&#229;/g, "å");
-  var cleanHtml = cleanHtml.replace(/&#62;/g, ">");
-  var cleanHtml = cleanHtml.replace(/&#60;/g, ";");
-  var cleanHtml = cleanHtml.replace(/&#39;/g, "'");
-  var cleanHtml = cleanHtml.replace(/&#34;/g, '"');
-  var cleanHtml = cleanHtml.replace(/&#10;/g, "\n");
-  return cleanHtml;
+  // var cleanHtml = removeHtmlTags(content);
+  // var cleanHtml = cleanHtml.replace(/&#160;/g, " ");
+  // var cleanHtml = cleanHtml.replace(/&#230;/g, "æ");
+  // var cleanHtml = cleanHtml.replace(/&#248;/g, "ø");
+  // var cleanHtml = cleanHtml.replace(/&#229;/g, "å");
+  // var cleanHtml = cleanHtml.replace(/&#62;/g, ">");
+  // var cleanHtml = cleanHtml.replace(/&#60;/g, ";");
+  // var cleanHtml = cleanHtml.replace(/&#39;/g, "'");
+  // var cleanHtml = cleanHtml.replace(/&#34;/g, '"');
+  // var cleanHtml = cleanHtml.replace(/&#10;/g, "\n");
+  // var cleanHtml = cleanHtml.replace("cons", "TEST");
+  // return cleanHtml;
+  return content;
 }
 
 function removeHtmlTags(htmlString: string) {
   var stripedHtml = htmlString.replace(/<p>/g, "");
   var stripedHtml = stripedHtml.replace(/<\/p>/g, "\n");
-  var stripedHtml = stripedHtml.replace(/<strong>/g, "\n");
-  var stripedHtml = stripedHtml.replace(/<\/strong>/g, "\n");
+  var stripedHtml = stripedHtml.replace(/<strong>/g, "");
+  var stripedHtml = stripedHtml.replace(/<\/strong>/g, "");
   var stripedHtml = stripedHtml.replace(/<em>/g, "\n");
   var stripedHtml = stripedHtml.replace(/<\/em>/g, "\n");
   return stripedHtml;
@@ -55,6 +57,7 @@ export function insperaDataToTextboxObject(
         candidate.result.ext_inspera_questions[questionNumber - 1]
           .ext_inspera_candidateResponses[0].ext_inspera_response
       ),
+
       candidateId: parseInt(candidate.result.ext_inspera_candidateId),
       maxPoints:
         candidate.result.ext_inspera_questions[questionNumber - 1]

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -1,33 +1,11 @@
 import { v4 as uuidv4 } from "uuid";
 import { AssessmentType } from "../types/Types";
 
-function cleanHtmlText(content: string) {
+function replaceUndefined(content: string) {
   if (content == undefined) {
     return "";
   }
-  // var cleanHtml = removeHtmlTags(content);
-  // var cleanHtml = cleanHtml.replace(/&#160;/g, " ");
-  // var cleanHtml = cleanHtml.replace(/&#230;/g, "æ");
-  // var cleanHtml = cleanHtml.replace(/&#248;/g, "ø");
-  // var cleanHtml = cleanHtml.replace(/&#229;/g, "å");
-  // var cleanHtml = cleanHtml.replace(/&#62;/g, ">");
-  // var cleanHtml = cleanHtml.replace(/&#60;/g, ";");
-  // var cleanHtml = cleanHtml.replace(/&#39;/g, "'");
-  // var cleanHtml = cleanHtml.replace(/&#34;/g, '"');
-  // var cleanHtml = cleanHtml.replace(/&#10;/g, "\n");
-  // var cleanHtml = cleanHtml.replace("cons", "TEST");
-  // return cleanHtml;
   return content;
-}
-
-function removeHtmlTags(htmlString: string) {
-  var stripedHtml = htmlString.replace(/<p>/g, "");
-  var stripedHtml = stripedHtml.replace(/<\/p>/g, "\n");
-  var stripedHtml = stripedHtml.replace(/<strong>/g, "");
-  var stripedHtml = stripedHtml.replace(/<\/strong>/g, "");
-  var stripedHtml = stripedHtml.replace(/<em>/g, "\n");
-  var stripedHtml = stripedHtml.replace(/<\/em>/g, "\n");
-  return stripedHtml;
 }
 
 export interface AnswerType {
@@ -53,7 +31,7 @@ export function insperaDataToTextboxObject(
   insperaData.ext_inspera_candidates.map((candidate: any) => {
     textboxData.push({
       assessmentId: uuidv4(),
-      answer: cleanHtmlText(
+      answer: replaceUndefined(
         candidate.result.ext_inspera_questions[questionNumber - 1]
           .ext_inspera_candidateResponses[0].ext_inspera_response
       ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1985,10 +1985,50 @@
         "csstype": "^3.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        }
+      }
+    },
     "domain-browser": {
       "version": "4.19.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+    },
+    "domhandler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+      "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -2051,6 +2091,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3029,6 +3074,37 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "html-dom-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.1.0.tgz",
+      "integrity": "sha512-x3MOz8S8BkihGgggtp2N0U+JAWlD9iGERbjuBJH+gIGF9B1kGQh5x489IQ0YPqi8HyMIWCRLdJY1q3IaQlqG/Q==",
+      "requires": {
+        "domhandler": "4.3.0",
+        "htmlparser2": "7.2.0"
+      }
+    },
+    "html-react-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.8.tgz",
+      "integrity": "sha512-5XsBdFVhJLxdtRp7tWwZ6DwqOt6fJ+2lJc0lctwjX1yaxWNB41S5uzqii7vJcSCaabM+CK28U75e5f4wIMqdSg==",
+      "requires": {
+        "domhandler": "4.3.0",
+        "html-dom-parser": "1.1.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
     "http-errors": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
@@ -3165,6 +3241,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -4794,6 +4875,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -5311,6 +5397,22 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "requires": {
+        "style-to-object": "0.3.0"
+      }
+    },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "styled-jsx": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/uuid": "^8.3.4",
     "@zeit/next-css": "^1.0.1",
     "bootstrap": "^5.1.3",
+    "html-react-parser": "^1.4.8",
     "lodash": "^4.17.21",
     "material-ui-icons": "^1.0.0-beta.36",
     "next": "^11.1.2",

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -19,7 +19,7 @@
 
 .card p {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: 1rem;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
fix #32
fix #77 

Added a converter that parses the html that wrap the student answers and returns beautiful text.
There is an edge case that if the student answers consist of html, it will be parsed and not displayed as a string in the text. 

![image](https://user-images.githubusercontent.com/44196526/157242544-d5388be1-b5d3-43c0-ba29-3945823fe407.png)
