### PR TITLE
Enable and disable realgorithm

### DIFF
--- a/components/consistencybox.tsx
+++ b/components/consistencybox.tsx
@@ -114,6 +114,7 @@ const ConsistencyBox: React.FC<{}> = () => {
             />
           )}
           <ExpandMore
+            sx={{ marginLeft: '3rem' }}
             expand={expanded}
             onClick={handleExpandClick}
             aria-expanded={expanded}

--- a/components/consistencybox.tsx
+++ b/components/consistencybox.tsx
@@ -14,11 +14,6 @@ import RadioGroup from "@mui/material/RadioGroup";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 
-interface InfoboxProps {
-  title: string;
-  content: string;
-}
-
 interface ExpandMoreProps extends IconButtonProps {
   expand: boolean;
 }
@@ -34,7 +29,7 @@ const ExpandMore = styled((props: ExpandMoreProps) => {
   }),
 }));
 
-const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
+const ConsistencyBox: React.FC<{}> = () => {
   const [checked, setChecked] = useState<boolean>(true);
   const [expanded, setExpanded] = useState<boolean>(false);
   const [radioValue, setRadioValue] = useState<string>("tilfeldig");
@@ -81,14 +76,15 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
     setRadioValue((event.target as HTMLInputElement).value);
   };
 
+  const title = "Konsistenssjekk";
+  const content = "Sjekken velger ut X antall besvarelser for revurdering.";
+
   return (
     <div style={{ margin: "1rem" }}>
       <Card sx={{ maxWidth: 400 }}>
         <CardContent>
-          <div style={{ marginBottom: 10, fontWeight: "bold" }}>
-            {props.title}
-          </div>
-          <div>{props.content}</div>
+          <div style={{ marginBottom: 10, fontWeight: "bold" }}>{title}</div>
+          <div>{content}</div>
         </CardContent>
         <CardContent>Bruk konsistenssjekk:</CardContent>
         <CardActions>
@@ -175,4 +171,4 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
   );
 };
 
-export default Infobox;
+export default ConsistencyBox;

--- a/components/consistencybox.tsx
+++ b/components/consistencybox.tsx
@@ -1,30 +1,35 @@
-import * as React from "react";
-import { useState } from "react";
-import Card from "@mui/material/Card";
-import CardActions from "@mui/material/CardActions";
-import CardContent from "@mui/material/CardContent";
-import Switch from "@mui/material/Switch";
-import Slider from "@mui/material/Slider";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import IconButton, { IconButtonProps } from "@mui/material/IconButton";
-import { styled } from "@mui/material/styles";
-import Collapse from "@mui/material/Collapse";
-import Radio from "@mui/material/Radio";
-import RadioGroup from "@mui/material/RadioGroup";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import FormControl from "@mui/material/FormControl";
+import * as React from 'react';
+import { useState } from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Switch from '@mui/material/Switch';
+import Slider from '@mui/material/Slider';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+import { styled } from '@mui/material/styles';
+import Collapse from '@mui/material/Collapse';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormControl from '@mui/material/FormControl';
 
 interface ExpandMoreProps extends IconButtonProps {
   expand: boolean;
+}
+
+interface Option {
+  value: string;
+  label: string;
 }
 
 const ExpandMore = styled((props: ExpandMoreProps) => {
   const { expand, ...other } = props;
   return <IconButton {...other} />;
 })(({ theme, expand }) => ({
-  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
-  marginLeft: "auto",
-  transition: theme.transitions.create("transform", {
+  transform: !expand ? 'rotate(0deg)' : 'rotate(180deg)',
+  marginLeft: 'auto',
+  transition: theme.transitions.create('transform', {
     duration: theme.transitions.duration.shortest,
   }),
 }));
@@ -32,41 +37,34 @@ const ExpandMore = styled((props: ExpandMoreProps) => {
 const ConsistencyBox: React.FC<{}> = () => {
   const [checked, setChecked] = useState<boolean>(true);
   const [expanded, setExpanded] = useState<boolean>(false);
-  const [radioValue, setRadioValue] = useState<string>("tilfeldig");
+  const [radioValue, setRadioValue] = useState<string>('random');
 
   const marks = [
-    {
-      value: 0,
-      label: "0%",
-    },
-    {
-      value: 20,
-      label: "20%",
-    },
-    {
-      value: 40,
-      label: "40%",
-    },
-    {
-      value: 60,
-      label: "60%",
-    },
-    {
-      value: 80,
-      label: "80%",
-    },
-    {
-      value: 100,
-      label: "100%",
-    },
+    { value: 0, label: '0%' },
+    { value: 20, label: '20%' },
+    { value: 40, label: '40%' },
+    { value: 60, label: '60%' },
+    { value: 80, label: '80%' },
+    { value: 100, label: '100%' },
   ];
+
+  const options: Option[] = [
+    { value: 'random', label: 'Tilfeldig' },
+    { value: 'scores_alike', label: 'Like scores' },
+    { value: 'scores_unlike', label: 'Ulike scores' },
+    { value: 'correlation', label: 'Korrelasjon' },
+  ];
+
+  const title = 'Konsistenssjekk';
+  const content = 'Sjekken velger ut X antall besvarelser for revurdering.';
+
+  function valuetext(value: number) {
+    return `${value}%`;
+  }
 
   const handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(event.target.checked);
   };
-  function valuetext(value: number) {
-    return `${value}%`;
-  }
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -76,14 +74,11 @@ const ConsistencyBox: React.FC<{}> = () => {
     setRadioValue((event.target as HTMLInputElement).value);
   };
 
-  const title = "Konsistenssjekk";
-  const content = "Sjekken velger ut X antall besvarelser for revurdering.";
-
   return (
-    <div style={{ margin: "1rem" }}>
+    <div style={{ margin: '1rem' }}>
       <Card sx={{ maxWidth: 400 }}>
         <CardContent>
-          <div style={{ marginBottom: 10, fontWeight: "bold" }}>{title}</div>
+          <div style={{ marginBottom: 10, fontWeight: 'bold' }}>{title}</div>
           <div>{content}</div>
         </CardContent>
         <CardContent>Bruk konsistenssjekk:</CardContent>
@@ -91,14 +86,14 @@ const ConsistencyBox: React.FC<{}> = () => {
           <Switch
             checked={checked}
             onChange={handleCheck}
-            inputProps={{ "aria-label": "controlled" }}
+            inputProps={{ 'aria-label': 'controlled' }}
           />
         </CardActions>
         <CardContent> Andel besvarelser som skal revurderes:</CardContent>
         <CardActions disableSpacing>
           {checked ? (
             <Slider
-              sx={{ marginLeft: "1.2rem", marginRight: "1rem" }}
+              sx={{ marginLeft: '1.2rem', marginRight: '1rem' }}
               aria-label="Custom marks"
               defaultValue={10}
               getAriaValueText={valuetext}
@@ -108,7 +103,7 @@ const ConsistencyBox: React.FC<{}> = () => {
             />
           ) : (
             <Slider
-              sx={{ marginLeft: "1.2rem", marginRight: "1rem" }}
+              sx={{ marginLeft: '1.2rem', marginRight: '1rem' }}
               disabled
               aria-label="Custom marks"
               defaultValue={10}
@@ -118,7 +113,6 @@ const ConsistencyBox: React.FC<{}> = () => {
               marks={marks}
             />
           )}
-
           <ExpandMore
             expand={expanded}
             onClick={handleExpandClick}
@@ -131,39 +125,46 @@ const ConsistencyBox: React.FC<{}> = () => {
         <Collapse in={expanded} timeout="auto" unmountOnExit>
           <CardContent>Velg type sjekk som ønskes:</CardContent>
           <CardActions>
-            <FormControl sx={{ marginLeft: "0.5rem" }}>
-              <RadioGroup
-                row
-                name="controlled-radio-buttons-group"
-                value={radioValue}
-                onChange={handleRadioClick}
-              >
-                <FormControlLabel
-                  value="random"
-                  control={<Radio />}
-                  label="Tilfeldig"
-                  disableTypography
-                />
-                <FormControlLabel
-                  value="scores_alike"
-                  control={<Radio />}
-                  label="Like scores"
-                  disableTypography
-                />
-                <FormControlLabel
-                  value="scores_unlike"
-                  control={<Radio />}
-                  label="Ulike scores"
-                  disableTypography
-                />
-                <FormControlLabel
-                  value="correlation"
-                  control={<Radio />}
-                  label="Korrelasjon"
-                  disableTypography
-                />
-              </RadioGroup>
-            </FormControl>
+            {checked ? (
+              <FormControl sx={{ marginLeft: '0.5rem' }}>
+                <RadioGroup
+                  row
+                  name="controlled-radio-buttons-group"
+                  value={radioValue}
+                  onChange={handleRadioClick}
+                >
+                  {options.map((option: Option) => (
+                    <FormControlLabel
+                      key={option.value}
+                      value={option.value}
+                      control={<Radio />}
+                      label={option.label}
+                      disableTypography
+                    />
+                  ))}
+                </RadioGroup>
+              </FormControl>
+            ) : (
+              <FormControl sx={{ marginLeft: '0.5rem' }}>
+                <RadioGroup
+                  row
+                  name="controlled-radio-buttons-group"
+                  value={radioValue}
+                  onChange={handleRadioClick}
+                >
+                  {options.map((option: Option) => (
+                    <FormControlLabel
+                      disabled
+                      key={option.value}
+                      value={option.value}
+                      control={<Radio />}
+                      label={option.label}
+                      disableTypography
+                    />
+                  ))}
+                </RadioGroup>
+              </FormControl>
+            )}
           </CardActions>
         </Collapse>
       </Card>

--- a/components/expand.tsx
+++ b/components/expand.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import { ExpandMore as ExpandMoreIcon } from "@material-ui/icons";
+import * as React from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import { ExpandMore as ExpandMoreIcon } from '@material-ui/icons';
 
 interface Expandprop {
   DescriptionTitle: string;
@@ -11,11 +11,10 @@ interface Expandprop {
 
 const Expand: React.FC<Expandprop> = (props: Expandprop) => {
   return (
-    <div style={{ margin: "1rem" }}>
+    <div style={{ margin: '1rem' }}>
       <Accordion
         sx={{
           width: 400,
-          boxShadow: "none",
         }}
       >
         <AccordionSummary

--- a/components/infobox.tsx
+++ b/components/infobox.tsx
@@ -102,7 +102,7 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
         <CardActions disableSpacing>
           {checked ? (
             <Slider
-              sx={{ marginLeft: "0.75rem", marginRight: "2rem" }}
+              sx={{ marginLeft: "1.2rem", marginRight: "1rem" }}
               aria-label="Custom marks"
               defaultValue={10}
               getAriaValueText={valuetext}
@@ -112,7 +112,7 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
             />
           ) : (
             <Slider
-              sx={{ marginLeft: "0.75rem", marginRight: "2rem" }}
+              sx={{ marginLeft: "1.2rem", marginRight: "1rem" }}
               disabled
               aria-label="Custom marks"
               defaultValue={10}
@@ -135,7 +135,7 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
         <Collapse in={expanded} timeout="auto" unmountOnExit>
           <CardContent>Velg type sjekk som ønskes:</CardContent>
           <CardActions>
-            <FormControl>
+            <FormControl sx={{ marginLeft: "0.5rem" }}>
               <RadioGroup
                 row
                 name="controlled-radio-buttons-group"
@@ -146,21 +146,25 @@ const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
                   value="random"
                   control={<Radio />}
                   label="Tilfeldig"
+                  disableTypography
                 />
                 <FormControlLabel
                   value="scores_alike"
                   control={<Radio />}
                   label="Like scores"
+                  disableTypography
                 />
                 <FormControlLabel
                   value="scores_unlike"
                   control={<Radio />}
                   label="Ulike scores"
+                  disableTypography
                 />
                 <FormControlLabel
                   value="correlation"
                   control={<Radio />}
                   label="Korrelasjon"
+                  disableTypography
                 />
               </RadioGroup>
             </FormControl>

--- a/components/infobox.tsx
+++ b/components/infobox.tsx
@@ -5,14 +5,39 @@ import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import Switch from "@mui/material/Switch";
 import Slider from "@mui/material/Slider";
-import Box from "@mui/material/Box";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import IconButton, { IconButtonProps } from "@mui/material/IconButton";
+import { styled } from "@mui/material/styles";
+import Collapse from "@mui/material/Collapse";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormControl from "@mui/material/FormControl";
 
-interface infoboxprop {
+interface InfoboxProps {
   title: string;
   content: string;
 }
-const Infobox: React.FC<infoboxprop> = (props: infoboxprop) => {
+
+interface ExpandMoreProps extends IconButtonProps {
+  expand: boolean;
+}
+
+const ExpandMore = styled((props: ExpandMoreProps) => {
+  const { expand, ...other } = props;
+  return <IconButton {...other} />;
+})(({ theme, expand }) => ({
+  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
+  marginLeft: "auto",
+  transition: theme.transitions.create("transform", {
+    duration: theme.transitions.duration.shortest,
+  }),
+}));
+
+const Infobox: React.FC<InfoboxProps> = (props: InfoboxProps) => {
   const [checked, setChecked] = useState<boolean>(true);
+  const [expanded, setExpanded] = useState<boolean>(false);
+  const [radioValue, setRadioValue] = useState<string>("tilfeldig");
 
   const marks = [
     {
@@ -41,12 +66,20 @@ const Infobox: React.FC<infoboxprop> = (props: infoboxprop) => {
     },
   ];
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(event.target.checked);
   };
   function valuetext(value: number) {
     return `${value}%`;
   }
+
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
+
+  const handleRadioClick = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRadioValue((event.target as HTMLInputElement).value);
+  };
 
   return (
     <div style={{ margin: "1rem" }}>
@@ -57,42 +90,82 @@ const Infobox: React.FC<infoboxprop> = (props: infoboxprop) => {
           </div>
           <div>{props.content}</div>
         </CardContent>
+        <CardContent>Bruk konsistenssjekk:</CardContent>
         <CardActions>
-          <div style={{ display: "flex", flexDirection: "column" }}>
-            <div style={{ marginLeft: "0.5rem" }}>Bruk konsistenssjekk:</div>
-            <Switch
-              checked={checked}
-              onChange={handleChange}
-              inputProps={{ "aria-label": "controlled" }}
-            />
-            <div style={{ marginTop: "2rem", marginLeft: "0.5rem" }}>
-              Andel besvarelser som skal revurderes:
-            </div>
-
-            <Box sx={{ width: 300, margin: "1rem" }}>
-              {checked ? (
-                <Slider
-                  aria-label="Custom marks"
-                  defaultValue={10}
-                  getAriaValueText={valuetext}
-                  step={10}
-                  valueLabelDisplay="auto"
-                  marks={marks}
-                />
-              ) : (
-                <Slider
-                  disabled
-                  aria-label="Custom marks"
-                  defaultValue={10}
-                  getAriaValueText={valuetext}
-                  step={10}
-                  valueLabelDisplay="auto"
-                  marks={marks}
-                />
-              )}
-            </Box>
-          </div>
+          <Switch
+            checked={checked}
+            onChange={handleCheck}
+            inputProps={{ "aria-label": "controlled" }}
+          />
         </CardActions>
+        <CardContent> Andel besvarelser som skal revurderes:</CardContent>
+        <CardActions disableSpacing>
+          {checked ? (
+            <Slider
+              sx={{ marginLeft: "0.75rem", marginRight: "2rem" }}
+              aria-label="Custom marks"
+              defaultValue={10}
+              getAriaValueText={valuetext}
+              step={10}
+              valueLabelDisplay="auto"
+              marks={marks}
+            />
+          ) : (
+            <Slider
+              sx={{ marginLeft: "0.75rem", marginRight: "2rem" }}
+              disabled
+              aria-label="Custom marks"
+              defaultValue={10}
+              getAriaValueText={valuetext}
+              step={10}
+              valueLabelDisplay="auto"
+              marks={marks}
+            />
+          )}
+
+          <ExpandMore
+            expand={expanded}
+            onClick={handleExpandClick}
+            aria-expanded={expanded}
+            aria-label="show more"
+          >
+            <ExpandMoreIcon />
+          </ExpandMore>
+        </CardActions>
+        <Collapse in={expanded} timeout="auto" unmountOnExit>
+          <CardContent>Velg type sjekk som ønskes:</CardContent>
+          <CardActions>
+            <FormControl>
+              <RadioGroup
+                row
+                name="controlled-radio-buttons-group"
+                value={radioValue}
+                onChange={handleRadioClick}
+              >
+                <FormControlLabel
+                  value="random"
+                  control={<Radio />}
+                  label="Tilfeldig"
+                />
+                <FormControlLabel
+                  value="scores_alike"
+                  control={<Radio />}
+                  label="Like scores"
+                />
+                <FormControlLabel
+                  value="scores_unlike"
+                  control={<Radio />}
+                  label="Ulike scores"
+                />
+                <FormControlLabel
+                  value="correlation"
+                  control={<Radio />}
+                  label="Korrelasjon"
+                />
+              </RadioGroup>
+            </FormControl>
+          </CardActions>
+        </Collapse>
       </Card>
     </div>
   );

--- a/components/infobox.tsx
+++ b/components/infobox.tsx
@@ -1,0 +1,101 @@
+import * as React from "react";
+import { useState } from "react";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardContent from "@mui/material/CardContent";
+import Switch from "@mui/material/Switch";
+import Slider from "@mui/material/Slider";
+import Box from "@mui/material/Box";
+
+interface infoboxprop {
+  title: string;
+  content: string;
+}
+const Infobox: React.FC<infoboxprop> = (props: infoboxprop) => {
+  const [checked, setChecked] = useState<boolean>(true);
+
+  const marks = [
+    {
+      value: 0,
+      label: "0%",
+    },
+    {
+      value: 20,
+      label: "20%",
+    },
+    {
+      value: 40,
+      label: "40%",
+    },
+    {
+      value: 60,
+      label: "60%",
+    },
+    {
+      value: 80,
+      label: "80%",
+    },
+    {
+      value: 100,
+      label: "100%",
+    },
+  ];
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+  };
+  function valuetext(value: number) {
+    return `${value}%`;
+  }
+
+  return (
+    <div style={{ margin: "1rem" }}>
+      <Card sx={{ maxWidth: 400 }}>
+        <CardContent>
+          <div style={{ marginBottom: 10, fontWeight: "bold" }}>
+            {props.title}
+          </div>
+          <div>{props.content}</div>
+        </CardContent>
+        <CardActions>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ marginLeft: "0.5rem" }}>Bruk konsistenssjekk:</div>
+            <Switch
+              checked={checked}
+              onChange={handleChange}
+              inputProps={{ "aria-label": "controlled" }}
+            />
+            <div style={{ marginTop: "2rem", marginLeft: "0.5rem" }}>
+              Andel besvarelser som skal revurderes:
+            </div>
+
+            <Box sx={{ width: 300, margin: "1rem" }}>
+              {checked ? (
+                <Slider
+                  aria-label="Custom marks"
+                  defaultValue={10}
+                  getAriaValueText={valuetext}
+                  step={10}
+                  valueLabelDisplay="auto"
+                  marks={marks}
+                />
+              ) : (
+                <Slider
+                  disabled
+                  aria-label="Custom marks"
+                  defaultValue={10}
+                  getAriaValueText={valuetext}
+                  step={10}
+                  valueLabelDisplay="auto"
+                  marks={marks}
+                />
+              )}
+            </Box>
+          </div>
+        </CardActions>
+      </Card>
+    </div>
+  );
+};
+
+export default Infobox;

--- a/package-lock.json
+++ b/package-lock.json
@@ -476,6 +476,24 @@
         }
       }
     },
+    "@mui/icons-material": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.5.1.tgz",
+      "integrity": "sha512-40f68p5+Yhq3dCn3QYHqQt5RETPyR3AkDw+fma8PtcjqvZ+d+jF84kFmT6NqwA3he7TlwluEtkyAmPzUE4uPdA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
+          "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@mui/material": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.5.0.tgz",
@@ -919,6 +937,16 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
+    "@types/material-ui": {
+      "version": "0.21.12",
+      "resolved": "https://registry.npmjs.org/@types/material-ui/-/material-ui-0.21.12.tgz",
+      "integrity": "sha512-rBY3iOr5LISKDLAYo3229R79xIPPKSOL2c7FzAFn5dUj38Oe7rQldYedHWsYmkJUeboE9Ipad7ppyJwBzXxrMw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/react-addons-linked-state-mixin": "*"
+      }
+    },
     "@types/node": {
       "version": "16.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
@@ -942,6 +970,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-addons-linked-state-mixin": {
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/@types/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.22.tgz",
+      "integrity": "sha512-DF9utM6VjuIaY388R6XWWDs7CIDTH7on1k1yR+hqaL/T4/OqSCW5uij28APq9KI82CZf0/qtBJI+pjvXcOh0kQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-is": {
@@ -1410,6 +1447,27 @@
         }
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1440,6 +1498,11 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
+    },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1613,6 +1676,11 @@
       "version": "1.0.30001265",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
       "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
+    },
+    "chain-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
+      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1828,6 +1896,15 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -3273,6 +3350,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "inline-style-prefixer": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+      "requires": {
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
+      }
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -3467,6 +3553,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -3692,6 +3783,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -3801,8 +3897,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -3813,6 +3908,11 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -3843,6 +3943,54 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
         "semver": "^6.0.0"
+      }
+    },
+    "material-ui": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.20.2.tgz",
+      "integrity": "sha512-VeqgQkdvtK193w+FFvXDEwlVxI4rWk83eWbpYLeOIHDPWr3rbB9B075JRnJt/8IsI2X8q5Aia5W3+7m4KkleDg==",
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "inline-style-prefixer": "^3.0.8",
+        "keycode": "^2.1.8",
+        "lodash.merge": "^4.6.0",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.5.7",
+        "react-event-listener": "^0.6.2",
+        "react-transition-group": "^1.2.1",
+        "recompose": "^0.26.0",
+        "simple-assign": "^0.1.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+          "requires": {
+            "chain-function": "^1.0.0",
+            "dom-helpers": "^3.2.0",
+            "loose-envify": "^1.3.1",
+            "prop-types": "^15.5.6",
+            "warning": "^3.0.0"
+          }
+        },
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "material-ui-icons": {
@@ -4896,6 +5044,16 @@
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ=="
     },
+    "react-event-listener": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
+      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.1"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -5216,6 +5374,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "simple-assign": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
+      "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bootstrap": "^5.1.3",
     "html-react-parser": "^1.4.8",
     "lodash": "^4.17.21",
+    "material-ui": "^0.20.2",
     "material-ui-icons": "^1.0.0-beta.36",
     "next": "^11.1.2",
     "react": "17.0.2",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.178",
+    "@types/material-ui": "^0.21.12",
     "@types/react": "17.0.21",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -5,7 +5,7 @@ import Textbox from "../components/textbox";
 import { useEffect, useState } from "react";
 import data from "../data/IT2810Høst2018.json";
 import Expand from "../components/expand";
-import Infobox from "../components/infobox";
+import Consistencybox from "../components/consistencybox";
 import {
   chooseCorrelatedAssessment,
   insperaDataToTextboxObject,
@@ -155,10 +155,7 @@ const Assessment: NextPage = () => {
               DescriptionTitle="Sensorveiledning"
               Description={markersGuideDescription}
             />
-            <Infobox
-              title="Konsistenssjekk"
-              content="Sjekken velger ut X antall besvarelser for revurdering."
-            ></Infobox>
+            <Consistencybox />
           </div>
           <div className={styles.grid}>
             {assessments

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -5,6 +5,7 @@ import Textbox from "../components/textbox";
 import { useEffect, useState } from "react";
 import data from "../data/IT2810Høst2018.json";
 import Expand from "../components/expand";
+import Infobox from "../components/infobox";
 import {
   chooseCorrelatedAssessment,
   insperaDataToTextboxObject,
@@ -154,6 +155,10 @@ const Assessment: NextPage = () => {
               DescriptionTitle="Sensorveiledning"
               Description={markersGuideDescription}
             />
+            <Infobox
+              title="Konsistenssjekk"
+              content="Velg om du vil bruke konsistenssjekken. Sjekken velger ut X antall besvarelser for revurdering."
+            ></Infobox>
           </div>
           <div className={styles.grid}>
             {assessments

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -157,7 +157,7 @@ const Assessment: NextPage = () => {
             />
             <Infobox
               title="Konsistenssjekk"
-              content="Velg om du vil bruke konsistenssjekken. Sjekken velger ut X antall besvarelser for revurdering."
+              content="Sjekken velger ut X antall besvarelser for revurdering."
             ></Infobox>
           </div>
           <div className={styles.grid}>


### PR DESCRIPTION
fix #85 

The user has an option for choosing to enable or disable the consistency check. The user can also choose the maximum limit on how many answers that may be reassessed. By clicking the expand button, the user have the possibility to choose between four different re-algorithms.

Note that this is only the GUI and that the backend is not implemented.

When the realgorithm is enabled:
![image](https://user-images.githubusercontent.com/44196526/159268702-b12975c7-c567-42f6-976e-0b3ba5450ebb.png)

When it is disabled:
![image](https://user-images.githubusercontent.com/44196526/159268777-54e524c8-a129-4bf9-bd99-2acd820a879e.png)
