### PR TITLE
Add the same font 

### DIFF
--- a/components/approvalTextbox.tsx
+++ b/components/approvalTextbox.tsx
@@ -1,22 +1,23 @@
-import * as React from "react";
-import {ApprovalType} from "../types/Types";
-import Grid from "@mui/material/Grid";
-import Paper from "@mui/material/Paper";
-import Typography from "@mui/material/Typography";
-import parse from "html-react-parser";
+import * as React from 'react';
+import { ApprovalType } from '../types/Types';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import parse from 'html-react-parser';
 
 interface approvalTexboxProp {
-  assessment: ApprovalType
+  assessment: ApprovalType;
 }
 
 const ApprovalTextbox: React.FC<approvalTexboxProp> = (
-  props: approvalTexboxProp,
+  props: approvalTexboxProp
 ) => {
-
-  let inconsistentScoresString = "";
+  let inconsistentScoresString = '';
   if (props.assessment.inconsistentScores) {
-    props.assessment.inconsistentScores.length == 2 ?
-      inconsistentScoresString += props.assessment.inconsistentScores[0].toString() + " og " + props.assessment.inconsistentScores[1].toString()
+    props.assessment.inconsistentScores.length == 2
+      ? (inconsistentScoresString +=
+          props.assessment.inconsistentScores[0].toString() +
+          ' og ' +
+          props.assessment.inconsistentScores[1].toString())
       : null;
   }
   // As of now it only supports 2 inconsistent assessments
@@ -24,32 +25,27 @@ const ApprovalTextbox: React.FC<approvalTexboxProp> = (
 
   return (
     <div>
-      {showConflictError ?
-        <Typography variant="body1">Konflikt! Det er blitt satt
-          scorene: {inconsistentScoresString}
-        </Typography>
-        : null}
+      {showConflictError ? (
+        <div>
+          Konflikt! Det er blitt satt scorene: {inconsistentScoresString}
+        </div>
+      ) : null}
       <Paper
         sx={{
           p: 3,
-          margin: "auto",
+          margin: 'auto',
           width: 800,
           border: showConflictError ? 3 : null,
-          borderColor: "#ce4d5f"
-        }}>
+          borderColor: '#ce4d5f',
+        }}
+      >
         <Grid container spacing={2}>
           <Grid item>
-            <Typography variant="subtitle1" component="div">
-              {props.assessment.candidateId}
-            </Typography>
-            <Typography variant="subtitle1" align="left" component="div">
-              {props.assessment.score} p
-            </Typography>
+            <div>{props.assessment.candidateId}</div>
+            <div>{props.assessment.score} p</div>
           </Grid>
-          <Grid item xs={12} sm container sx={{mt: 0.5}}>
-            <Typography variant="body2" gutterBottom component="div">
-              {parse(props.assessment.answer)}
-            </Typography>
+          <Grid item xs={12} sm container sx={{ mt: 0.5 }}>
+            <div>{parse(props.assessment.answer)}</div>
           </Grid>
         </Grid>
       </Paper>


### PR DESCRIPTION
#fix 65

The easiest and quickest solution for this issue was to remove `Typography` in the `approvalTextbox` and replace it with `<div>`. This was the only place where the font differed. If we want to change the overall font we can do it in `globals.css`. In addition to being the easiest solution, I also believe it is more convenient as `Typography` includes some styling such as padding. This might not always be wanted as we have some limited space for several components. meaning that we have to override and remove it.