### PR TITLE
88 styling

### DIFF
--- a/components/togglebuttons.tsx
+++ b/components/togglebuttons.tsx
@@ -18,7 +18,7 @@ const Togglebuttons: React.FC<Togglebuttonsprops> = (
 ) => {
   return (
     <ToggleButtonGroup
-      sx={{ display: 'block', maxWidth: '250px', marginRight: '4px' }}
+      sx={{ display: 'block', maxWidth: '250px' }}
       value={props.value.toString()}
       exclusive
       onChange={props.handleSetMaxItems}

--- a/styles/Main.module.css
+++ b/styles/Main.module.css
@@ -1,9 +1,11 @@
 .container {
+  min-width: 100vh;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: var(--main-color);
+  /* background-color: var(--main-color); */
+  background-color: rgb(190, 238, 190);
 }
 
 .main {
@@ -11,4 +13,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  background-color: rgb(115, 106, 168);
 }

--- a/styles/Main.module.css
+++ b/styles/Main.module.css
@@ -4,8 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* background-color: var(--main-color); */
-  background-color: rgb(190, 238, 190);
+  background-color: var(--main-color);
 }
 
 .main {
@@ -13,5 +12,4 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: rgb(115, 106, 168);
 }

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -7,8 +7,8 @@
   border: 1px solid var(--card-border);
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-  width: 630px;
-  height: 410px;
+  max-width: 630px;
+  max-height: 410px;
   background-color: var(--white);
 }
 

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -33,8 +33,8 @@
 
 .scrollable {
   overflow-y: scroll;
-  width: 595px;
-  height: 320px;
+  max-width: 595px;
+  max-height: 320px;
 }
 
 .pointboxAndFlag {

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -34,7 +34,7 @@
 .scrollable {
   overflow-y: scroll;
   max-width: 595px;
-  max-height: 260px;
+  max-height: 75%;
 }
 
 .pointboxAndFlag {

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -7,17 +7,8 @@
   border: 1px solid var(--card-border);
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
-<<<<<<< HEAD
-  max-width: 630px;
-  max-height: 410px;
-=======
-  width: 500px;
-
+  width: 45%;
   height: 360px;
-  position: relative;
-  /*hvis maxwidth -> noen ganger blir den mindre. Men på satt widht så skalerer den ikke*/
-
->>>>>>> fa6a54f (adjust to mac 13 size)
   background-color: var(--white);
 }
 
@@ -43,7 +34,7 @@
 .scrollable {
   overflow-y: scroll;
   max-width: 595px;
-  max-height: 320px;
+  max-height: 260px;
 }
 
 .pointboxAndFlag {

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -7,8 +7,17 @@
   border: 1px solid var(--card-border);
   border-radius: 10px;
   transition: color 0.15s ease, border-color 0.15s ease;
+<<<<<<< HEAD
   max-width: 630px;
   max-height: 410px;
+=======
+  width: 500px;
+
+  height: 360px;
+  position: relative;
+  /*hvis maxwidth -> noen ganger blir den mindre. Men på satt widht så skalerer den ikke*/
+
+>>>>>>> fa6a54f (adjust to mac 13 size)
   background-color: var(--white);
 }
 

--- a/styles/assessment.module.css
+++ b/styles/assessment.module.css
@@ -3,7 +3,7 @@
   width: 100% !important;
   flex-direction: row;
   justify-content: space-between;
-  margin: 0 1rem 0;
+  margin: 0 2.3rem 0;
   align-items: center;
 }
 
@@ -14,16 +14,14 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  background-color: pink;
 }
 
 .grid {
   display: flex;
   align-items: flex-start;
+  justify-content: center;
   flex-wrap: wrap;
-  padding-left: 0.5em;
   max-width: 86em;
-  background-color: antiquewhite;
 }
 
 .alignInfo {

--- a/styles/assessment.module.css
+++ b/styles/assessment.module.css
@@ -14,6 +14,7 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  background-color: pink;
 }
 
 .grid {
@@ -21,7 +22,8 @@
   align-items: flex-start;
   flex-wrap: wrap;
   padding-left: 3em;
-  width: 86em;
+  max-width: 86em;
+  background-color: antiquewhite;
 }
 
 .alignInfo {

--- a/styles/assessment.module.css
+++ b/styles/assessment.module.css
@@ -21,7 +21,7 @@
   display: flex;
   align-items: flex-start;
   flex-wrap: wrap;
-  padding-left: 3em;
+  padding-left: 0.5em;
   max-width: 86em;
   background-color: antiquewhite;
 }


### PR DESCRIPTION
fix #88 

Now the textboxes changes and wraps dynamically based on the screen size. The css is less cut off when you narrow the screen and look to the left. I did not figure out hot to fully fix it, but we can assume that people will not have such a narrow screen. 

The sorting and toggle components are now a bit weird aligned. I did not find out how to align it with the textboxes vertically as the textboxes may change, so sometimes the look like this:
![image](https://user-images.githubusercontent.com/44196526/161255781-1b2a70f7-b14b-4a0b-8723-4f6b1f366ffa.png)

And then for a smaller screen:
![image](https://user-images.githubusercontent.com/44196526/161255864-79ce87eb-b138-4379-8a10-e7ffe955a363.png)

