### PR TITLE
upload dataset from inspera to localstorage

### DIFF
--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { ApprovalType, AssessmentType } from '../types/Types';
+import data from '../data/IT2810Høst2018.json';
 
 function replaceUndefined(content: string) {
   if (content == undefined) {
@@ -190,4 +191,39 @@ export function chooseCorrelatedAssessment(
     return correlatedAssessments[index];
   }
   return null;
+}
+
+export function uploadDataToLocalstorage() {
+  const totalTasks: number =
+    data.ext_inspera_candidates[0].result.ext_inspera_questions.length;
+  const taskNumbers: number[] = Array.from(Array(totalTasks).keys());
+
+  //check if data is already uploaded to localstorage
+  if (typeof window !== 'undefined') {
+    taskNumbers.map((taskNum: number) => {
+      const key: string = (taskNum + 1).toString() + '_data';
+      const dataToBeUploaded: AnswerType[] = [];
+      // data is not uploaded
+      if (!(key in localStorage)) {
+        data.ext_inspera_candidates.map((candidate: any) => {
+          // create answer objects and add to list
+          dataToBeUploaded.push({
+            assessmentId: uuidv4(),
+            answer: replaceUndefined(
+              candidate.result.ext_inspera_questions[taskNum]
+                .ext_inspera_candidateResponses[0].ext_inspera_response
+            ),
+            candidateId: parseInt(candidate.result.ext_inspera_candidateId),
+            maxPoints:
+              candidate.result.ext_inspera_questions[taskNum]
+                .ext_inspera_maxQuestionScore,
+            taskNumber: taskNum + 1,
+          });
+        });
+
+        //add to localstorage
+        localStorage.setItem(key, JSON.stringify(dataToBeUploaded));
+      }
+    });
+  }
 }

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -50,10 +50,14 @@ const Assessment: NextPage = () => {
     'let - block scope. Dersom variabelen blir deklarert med let i en funksjon, er den bare tilgjengelig i funksjonen. var - global scope Dersom variabelen blir deklarert med var, blir den tilgjengelig i all kode. Kan by på problemer når vi gir variabler samme navn.';
 
   const allAnswers: AnswerType[] = insperaDataToTextboxObject(data, taskNumber);
-  const answers = allAnswers.slice(0,10);
+  const answers = allAnswers.slice(0, 10);
   const numberOfAnswers = answers.length;
 
-  const p = answers.map((answer: AnswerType) => ({ score: '', isFlagged: false, ...answer }));
+  const p = answers.map((answer: AnswerType) => ({
+    score: '',
+    isFlagged: false,
+    ...answer,
+  }));
   const [assessments, setAssessments] = useState<AssessmentType[]>(p);
 
   const maxItemsPerPage = parseInt(maxItems);
@@ -93,7 +97,8 @@ const Assessment: NextPage = () => {
     const maxReAssessmentPercentage = 0.2;
     if (
       // not currently assessing a reAssessment
-      currentPage * (maxItemsPerPage - 1) < numberOfAnswers
+      currentPage * (maxItemsPerPage - 1) <
+      numberOfAnswers
     ) {
       const assessment = chooseCorrelatedAssessment(batch);
       if (
@@ -128,9 +133,7 @@ const Assessment: NextPage = () => {
     setAssessments(newArr);
   };
 
-  const toggleFlag = (
-    assessment: AssessmentType,
-  ) => {
+  const toggleFlag = (assessment: AssessmentType) => {
     const newAssessment = {
       ...assessment,
       isFlagged: !assessment.isFlagged,
@@ -225,7 +228,12 @@ const Assessment: NextPage = () => {
           >
             <Button
               variant="contained"
-              onClick={() => saveBatch(assessments.slice(startIndexBatch, endIndexBatch), taskNumber)}
+              onClick={() =>
+                saveBatch(
+                  assessments.slice(startIndexBatch, endIndexBatch),
+                  taskNumber
+                )
+              }
             >
               {/*need to figure out a key, currently set to 0*/}
               Fullfør

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,8 +3,10 @@ import * as React from 'react';
 import styles from '../styles/Home.module.css';
 import Link from 'next/link';
 import { Button } from '@mui/material';
+import { uploadDataToLocalstorage } from '../functions/helpFunctions';
 
 const Home: NextPage = () => {
+  uploadDataToLocalstorage();
   return (
     <div className={styles.container}>
       <h1>Ditt datasett har blitt lastet opp. Vennligst fortsett.</h1>


### PR DESCRIPTION
fix #53 

Created a function that uploads the dataset to localstorage on this format key: `tasknumber_data`, value: `AnswerType[]`
![image](https://user-images.githubusercontent.com/44196526/161265442-0962cc48-e9e5-41a1-ae2a-1870ad7a293d.png)

To upload the data, we just have to call uploadDataToLocalstorage() in any file. I think it is convenient to place it in the index file.
What is missing now is to use data from localstorage in our other files. As for now it is only uploaded and not used anywhere. This issue is more related to #66 