### PR TITLE
buttons approval page

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,16 +8,16 @@ interface Headerprops {
   data: any;
   taskNumber?: number;
   description?: string;
-  page?: string;
+  goBackPage?: string;
 }
 
 const Header: React.FC<Headerprops> = (props: Headerprops) => {
   return (
     <div className={styles.headerstyle}>
-      {props.page == 'assessment' && props.taskNumber ? (
+      {props.goBackPage == 'assessment' && props.taskNumber ? (
         <Link
           href={{
-            pathname: '/' + props.page,
+            pathname: '/' + props.goBackPage,
             query: { task: props.taskNumber },
           }}
           passHref
@@ -34,7 +34,7 @@ const Header: React.FC<Headerprops> = (props: Headerprops) => {
       ) : (
         <Link
           href={{
-            pathname: '/' + props.page,
+            pathname: '/' + props.goBackPage,
           }}
           passHref
         >

--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -310,10 +310,13 @@ export function getAssessmentData(taskNum: string) {
 }
 
 // Help function to get the remaining answers
-function excludeArray2fromArray1(array1: AnswerType[], array2: AssessmentType[]) {
+function excludeArray2fromArray1(
+  array1: AnswerType[],
+  array2: AssessmentType[]
+) {
   return array1.filter((object1) => {
-    return !array2.some((object2) =>
-      object1.candidateId === object2.candidateId
+    return !array2.some(
+      (object2) => object1.candidateId === object2.candidateId
     );
   });
 }
@@ -321,4 +324,15 @@ function excludeArray2fromArray1(array1: AnswerType[], array2: AssessmentType[])
 // check if all scores are set
 export function checkScores(assessments: AssessmentType[]): boolean {
   return !assessments.some((e) => e.score === '');
+}
+
+// check if there are any inconsistent scores
+export function checkInconsistentScores(assessments: ApprovalType[]): boolean {
+  let status: boolean = false;
+  assessments.map((assessment) => {
+    if ('inconsistentScores' in assessment) {
+      status = true;
+    }
+  });
+  return status;
 }

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -18,6 +18,7 @@ import {
   checkInconsistentScores,
 } from '../functions/helpFunctions';
 import Tooltip from '@mui/material/Tooltip';
+import Header from '../components/header';
 
 const getAllAssessedAssessments = (taskNumber: number): AssessmentType[] => {
   const key = taskNumber.toString() + '_assessments';
@@ -86,6 +87,7 @@ const Approval: NextPage = () => {
   const router = useRouter();
 
   const [taskNumber, setTaskNumber] = useState<any>('');
+  const [taskTitle, setTaskTitle] = useState<string>('');
 
   const approvedAssessments: ApprovalType[] =
     getApprovedAssessments(taskNumber);
@@ -99,6 +101,11 @@ const Approval: NextPage = () => {
   useEffect(() => {
     if (!router.isReady) return;
     setTaskNumber(router.query.task);
+    setTaskTitle(
+      data.ext_inspera_candidates[0].result.ext_inspera_questions[
+        router.query.task - 1
+      ].ext_inspera_questionTitle
+    );
   }, [router.isReady, router.query.task]);
 
   useEffect(() => {
@@ -135,7 +142,12 @@ const Approval: NextPage = () => {
 
   return (
     <div className={styles.container}>
-      <h1>{data.ext_inspera_assessmentRunTitle}</h1>
+      <Header
+        data={data}
+        taskNumber={taskNumber}
+        description={taskTitle}
+        goBackPage="assessment"
+      />
       <main className={styles.main}>
         <Grid container gap={2} xs={5} item={true}>
           {assessments.map((assessment: ApprovalType) => (
@@ -147,36 +159,25 @@ const Approval: NextPage = () => {
           ))}
         </Grid>
         <div style={{ padding: 20 }}>
-          <Link
-            href={{
-              pathname: '/assessment',
-              query: { task: taskNumber },
-            }}
-            passHref
-          >
-            <Button sx={{ textTransform: 'none' }} variant="contained">
-              Tilbake
-            </Button>
-          </Link>
-          <Link href="/task" passHref>
-            {checkInconsistentScores(assessments) == true ? (
-              <Tooltip
-                title={
-                  <h3>For å godkjenne vurderingen må alle konflikter løses.</h3>
-                }
-              >
-                <span>
-                  <Button
-                    disabled
-                    sx={{ textTransform: 'none' }}
-                    variant="contained"
-                    onClick={() => saveAssessments(filteredAssessments, key)}
-                  >
-                    Godkjenn vurdering av oppgave {taskNumber}
-                  </Button>
-                </span>
-              </Tooltip>
-            ) : (
+          {checkInconsistentScores(assessments) == true ? (
+            <Tooltip
+              title={
+                <h3>For å godkjenne vurderingen må alle konflikter løses.</h3>
+              }
+            >
+              <span>
+                <Button
+                  disabled
+                  sx={{ textTransform: 'none' }}
+                  variant="contained"
+                  onClick={() => saveAssessments(filteredAssessments, key)}
+                >
+                  Godkjenn vurdering av oppgave {taskNumber}
+                </Button>
+              </span>
+            </Tooltip>
+          ) : (
+            <Link href="/task" passHref>
               <Button
                 sx={{ textTransform: 'none', marginLeft: 10 }}
                 variant="contained"
@@ -184,8 +185,8 @@ const Approval: NextPage = () => {
               >
                 Godkjenn vurdering av oppgave {taskNumber}
               </Button>
-            )}
-          </Link>
+            </Link>
+          )}
         </div>
       </main>
     </div>

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -15,7 +15,9 @@ import cloneDeep from 'lodash/cloneDeep';
 import {
   saveAssessments,
   getApprovedAssessments,
+  checkInconsistentScores,
 } from '../functions/helpFunctions';
+import Tooltip from '@mui/material/Tooltip';
 
 const getAllAssessedAssessments = (taskNumber: number): AssessmentType[] => {
   const key = taskNumber.toString() + '_assessments';
@@ -152,16 +154,37 @@ const Approval: NextPage = () => {
             }}
             passHref
           >
-            <Button variant="contained">Tilbake</Button>
+            <Button sx={{ textTransform: 'none' }} variant="contained">
+              Tilbake
+            </Button>
           </Link>
           <Link href="/task" passHref>
-            <Button
-              style={{ marginLeft: 10 }}
-              variant="contained"
-              onClick={() => saveAssessments(assessments, key)}
-            >
-              Fullfør
-            </Button>
+            {checkInconsistentScores(assessments) == true ? (
+              <Tooltip
+                title={
+                  <h3>For å godkjenne vurderingen må alle konflikter løses.</h3>
+                }
+              >
+                <span>
+                  <Button
+                    disabled
+                    sx={{ textTransform: 'none' }}
+                    variant="contained"
+                    onClick={() => saveAssessments(filteredAssessments, key)}
+                  >
+                    Godkjenn vurdering av oppgave {taskNumber}
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <Button
+                sx={{ textTransform: 'none', marginLeft: 10 }}
+                variant="contained"
+                onClick={() => saveAssessments(filteredAssessments, key)}
+              >
+                Godkjenn vurdering av oppgave {taskNumber}
+              </Button>
+            )}
           </Link>
         </div>
       </main>

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -170,7 +170,7 @@ const Approval: NextPage = () => {
                   disabled
                   sx={{ textTransform: 'none' }}
                   variant="contained"
-                  onClick={() => saveAssessments(filteredAssessments, key)}
+                  onClick={() => saveAssessments(assessments, key)}
                 >
                   Godkjenn vurdering av oppgave {taskNumber}
                 </Button>
@@ -181,7 +181,7 @@ const Approval: NextPage = () => {
               <Button
                 sx={{ textTransform: 'none', marginLeft: 10 }}
                 variant="contained"
-                onClick={() => saveAssessments(filteredAssessments, key)}
+                onClick={() => saveAssessments(assessments, key)}
               >
                 Godkjenn vurdering av oppgave {taskNumber}
               </Button>

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -173,7 +173,7 @@ const Assessment: NextPage = () => {
         data={data}
         taskNumber={taskNumber}
         description={taskTitle}
-        page="task"
+        goBackPage="task"
       />
       <main className={mainStyles.main}>
         <div className={styles.alignInfo}>

--- a/pages/task.tsx
+++ b/pages/task.tsx
@@ -28,7 +28,7 @@ const Task: NextPage = () => {
       <Header
         data={data}
         description={'Oversikt over alle oppgavene'}
-        page=""
+        goBackPage=""
       />
       <main style={{ display: 'flex', justifyContent: 'center' }}>
         <Grid container gap={4} sx={{ maxWidth: 1230 }}>


### PR DESCRIPTION
fix #103 
fix #58 

Removed the `Tilbake` button on the page and added a back arrow to the assessment page instead. 
Added tooltip and check for approval so one cannot approve unless all conflicts are solved. 

One thing is that this looks kind of similar to the assessment page now as the header is the same. Maybe we need to do some adjustments here.  I added a suggestion on this PR #119 

This PR has a lot of commits because and is confusing because I struggled with some merging with another branch related to #117  

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/44196526/162007526-6c5dd714-4c38-4cb1-a7e2-540b47006807.png">


