### PR TITLE
possible fix of approval header

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -50,7 +50,7 @@ const Header: React.FC<Headerprops> = (props: Headerprops) => {
       )}
 
       <div className={styles.titles}>
-        {props.taskNumber && props.description ? (
+        {props.taskNumber && props.description && props.goBackPage == 'task' ? (
           <h1>
             Oppgave {props.taskNumber} : {props.description}
           </h1>

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -144,9 +144,9 @@ const Approval: NextPage = () => {
     <div className={styles.container}>
       <Header
         data={data}
-        taskNumber={taskNumber}
-        description={taskTitle}
+        description={'Godkjenning av oppgave ' + taskNumber + ': ' + taskTitle}
         goBackPage="assessment"
+        taskNumber={taskNumber}
       />
       <main className={styles.main}>
         <Grid container gap={2} xs={5} item={true}>


### PR DESCRIPTION
Ref comment in #118. This is branched out from #118 
I added another title to distinguish the `assessment page`and `approval page` more. 
<img width="1423" alt="image" src="https://user-images.githubusercontent.com/44196526/162016957-b35b38e3-3e01-4cc8-9ce5-4259c7fcf70f.png">
