### PR TITLE
Create grade based point scoring system

### DIFF
--- a/components/approvalTextbox.tsx
+++ b/components/approvalTextbox.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react';
+import styles from '../styles/Textbox.module.css';
 import { ApprovalType, AssessmentType } from '../types/Types';
-import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import parse from 'html-react-parser';
-import Pointsbox from "./pointsbox";
+import Gradingbuttons from './gradingbuttons';
+import { Button } from '@mui/material';
+import FlagIcon from '@mui/icons-material/Flag';
 
 interface approvalTexboxProp {
   assessment: ApprovalType;
-  setAssessmentScore: (assessment: AssessmentType, newScore: number) => void;
+  setAssessmentScore: (
+    assessment: AssessmentType,
+    newScore: number | string
+  ) => void;
+  toggleFlag: (assessment: ApprovalType) => void;
 }
 
 const ApprovalTextbox: React.FC<approvalTexboxProp> = (
@@ -37,23 +43,36 @@ const ApprovalTextbox: React.FC<approvalTexboxProp> = (
           p: 3,
           margin: 'auto',
           width: 800,
-          border: showConflictError || typeof props.assessment.score == "string" ? 3 : null,
+          border:
+            showConflictError || typeof props.assessment.score == 'string'
+              ? 3
+              : null,
           borderColor: '#ce4d5f',
         }}
       >
-        <Grid container spacing={2}>
-          <Grid item>
+        <div className={styles.approvalTextboxCard}>
+          <div className={styles.approvalTextboxContent}>
             <strong>{props.assessment.candidateId}</strong>
-            <Pointsbox
-              assessment={props.assessment}
-              setAssessmentScore={props.setAssessmentScore}
-              topMargin={"1em"}
-            />
-          </Grid>
-          <Grid item xs={12} sm container sx={{ mt: -2 }}>
-            <div>{parse(props.assessment.answer)}</div>
-          </Grid>
-        </Grid>
+            <div className={styles.approvalTextboxContent}>
+              <Gradingbuttons
+                assessment={props.assessment}
+                score={props.assessment.score}
+                setAssessmentScore={props.setAssessmentScore}
+              />
+              <Button
+                style={{ marginLeft: 15 }}
+                onClick={() => props.toggleFlag(props.assessment)}
+              >
+                {props.assessment.isFlagged ? (
+                  <FlagIcon color="secondary" />
+                ) : (
+                  <FlagIcon color="primary" />
+                )}
+              </Button>
+            </div>
+          </div>
+          <div>{parse(props.assessment.answer)}</div>
+        </div>
       </Paper>
     </div>
   );

--- a/components/approvalTextbox.tsx
+++ b/components/approvalTextbox.tsx
@@ -19,14 +19,15 @@ interface approvalTexboxProp {
 const ApprovalTextbox: React.FC<approvalTexboxProp> = (
   props: approvalTexboxProp
 ) => {
+  const grades = ['F', 'E', 'D', 'C', 'B', 'A']
   let inconsistentScoresString = '';
   if (props.assessment.inconsistentScores) {
     props.assessment.inconsistentScores.length == 2
       ? (inconsistentScoresString +=
-          props.assessment.inconsistentScores[0].toString() +
+          grades[Math.round((props.assessment.inconsistentScores[0] * props.assessment.maxPoints) * 5)] +
           ' og ' +
-          props.assessment.inconsistentScores[1].toString())
-      : null;
+          grades[Math.round((props.assessment.inconsistentScores[1] * props.assessment.maxPoints) * 5)])
+  : null;
   }
   // As of now it only supports 2 inconsistent assessments
   const showConflictError = inconsistentScoresString.length > 0;
@@ -35,7 +36,7 @@ const ApprovalTextbox: React.FC<approvalTexboxProp> = (
     <div>
       {showConflictError ? (
         <div>
-          Konflikt! Det er blitt satt scorene: {inconsistentScoresString}
+          Konflikt! Det er blitt satt karakterene: {inconsistentScoresString}
         </div>
       ) : null}
       <Paper

--- a/components/gradingbuttons.tsx
+++ b/components/gradingbuttons.tsx
@@ -15,25 +15,22 @@ interface Gradingbuttonprops {
 const Gradingbuttons: React.FC<Gradingbuttonprops> = (
   props: Gradingbuttonprops
 ) => {
-  const gradeScores = ['0', '1', '2', '3', '4', '5'];
   const gradeLabels = ['F', 'E', 'D', 'C', 'B', 'A'];
 
-  // for later calculation
-  const maxPoints = props.assessment.maxPoints;
-
   const handleChange = (selectedOption: any) => {
-    props.setAssessmentScore(props.assessment, selectedOption.target.value);
+    props.setAssessmentScore(props.assessment, selectedOption.target.value/5)
   };
+  const value = typeof props.assessment.score == 'number' ? (props.assessment.score/props.assessment.maxPoints) * 5 : '';
 
   return (
     <ToggleButtonGroup
-      value={props.assessment.score}
+      value={value}
       exclusive
       onChange={handleChange}
     >
-      {gradeScores.map((score: string, i: number) => (
-        <ToggleButton key={gradeLabels[i]} value={score}>
-          {gradeLabels[i]}
+      {gradeLabels.map((label: string, i: number) => (
+        <ToggleButton key={label} value={i}>
+          {label}
         </ToggleButton>
       ))}
     </ToggleButtonGroup>

--- a/components/gradingbuttons.tsx
+++ b/components/gradingbuttons.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { ApprovalType, AssessmentType } from '../types/Types';
+
+interface Gradingbuttonprops {
+  score: string | number;
+  assessment: AssessmentType | ApprovalType;
+  setAssessmentScore: (
+    assessment: AssessmentType | ApprovalType,
+    newScore: string | number
+  ) => void;
+}
+
+const Gradingbuttons: React.FC<Gradingbuttonprops> = (
+  props: Gradingbuttonprops
+) => {
+  const gradeScores = ['0', '1', '2', '3', '4', '5'];
+  const gradeLabels = ['F', 'E', 'D', 'C', 'B', 'A'];
+
+  // for later calculation
+  const maxPoints = props.assessment.maxPoints;
+
+  const handleChange = (selectedOption: any) => {
+    props.setAssessmentScore(props.assessment, selectedOption.target.value);
+  };
+
+  return (
+    <ToggleButtonGroup
+      value={props.assessment.score}
+      exclusive
+      onChange={handleChange}
+    >
+      {gradeScores.map((score: string, i: number) => (
+        <ToggleButton key={gradeLabels[i]} value={score}>
+          {gradeLabels[i]}
+        </ToggleButton>
+      ))}
+    </ToggleButtonGroup>
+  );
+};
+
+export default Gradingbuttons;

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -1,14 +1,18 @@
-import * as React from "react";
-import styles from "../styles/Textbox.module.css";
-import Pointsbox from "./pointsbox";
-import { AssessmentType } from "../types/Types";
-import parse from "html-react-parser";
-import { Button } from "@mui/material";
+import * as React from 'react';
+import styles from '../styles/Textbox.module.css';
+import Pointsbox from './pointsbox';
+import { ApprovalType, AssessmentType } from '../types/Types';
+import parse from 'html-react-parser';
+import { Button } from '@mui/material';
 import FlagIcon from '@mui/icons-material/Flag';
+import Gradingbuttons from './gradingbuttons';
 
 interface textboxprop {
   assessment: AssessmentType;
-  setAssessmentScore: (assessment: AssessmentType, newScore: number) => void;
+  setAssessmentScore: (
+    assessment: AssessmentType | ApprovalType,
+    newScore: string | number
+  ) => void;
   toggleFlag: (assessment: AssessmentType) => void;
 }
 
@@ -18,15 +22,17 @@ const Textbox: React.FC<textboxprop> = (props: textboxprop) => {
       <div className={styles.alignItems}>
         Besvarelse fra kandidat: {props.assessment.candidateId}
         <div className={styles.pointboxAndFlag}>
-          <Pointsbox
+          <Gradingbuttons
             assessment={props.assessment}
+            score={props.assessment.score}
             setAssessmentScore={props.setAssessmentScore}
-            topMargin={"0"}
-          />
+          ></Gradingbuttons>
           <Button onClick={() => props.toggleFlag(props.assessment)}>
-            {props.assessment.isFlagged ?
-              <FlagIcon color="secondary"/> : <FlagIcon color="primary"/>
-            }
+            {props.assessment.isFlagged ? (
+              <FlagIcon color="secondary" />
+            ) : (
+              <FlagIcon color="primary" />
+            )}
           </Button>
         </div>
       </div>

--- a/components/textbox.tsx
+++ b/components/textbox.tsx
@@ -26,7 +26,7 @@ const Textbox: React.FC<textboxprop> = (props: textboxprop) => {
             assessment={props.assessment}
             score={props.assessment.score}
             setAssessmentScore={props.setAssessmentScore}
-          ></Gradingbuttons>
+          />
           <Button onClick={() => props.toggleFlag(props.assessment)}>
             {props.assessment.isFlagged ? (
               <FlagIcon color="secondary" />

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -125,7 +125,6 @@ const Approval: NextPage = () => {
     typeof percentage == 'number'
       ? (newScore = percentage * assessment.maxPoints)
       : null;
-    console.log('points: ', newScore, ' of ', assessment.maxPoints);
     const newAssessment: AssessmentType = {
       assessmentId: assessment.assessmentId,
       answer: assessment.answer,

--- a/pages/approval.tsx
+++ b/pages/approval.tsx
@@ -119,8 +119,13 @@ const Approval: NextPage = () => {
 
   const setAssessmentScore = (
     assessment: AssessmentType,
-    newScore: number | string
+    percentage: number | string
   ) => {
+    let newScore: number | string = percentage;
+    typeof percentage == 'number'
+      ? (newScore = percentage * assessment.maxPoints)
+      : null;
+    console.log('points: ', newScore, ' of ', assessment.maxPoints);
     const newAssessment: AssessmentType = {
       assessmentId: assessment.assessmentId,
       answer: assessment.answer,
@@ -136,6 +141,19 @@ const Approval: NextPage = () => {
     const newArr: AssessmentType[] = cloneDeep(assessments);
     newArr.splice(index, 1, newAssessment);
 
+    setAssessments(newArr);
+  };
+
+  const toggleFlag = (assessment: ApprovalType) => {
+    const newAssessment = {
+      ...assessment,
+      isFlagged: !assessment.isFlagged,
+    };
+    const index = findIndex(assessments, {
+      assessmentId: assessment.assessmentId,
+    });
+    const newArr: AssessmentType[] = cloneDeep(assessments);
+    newArr.splice(index, 1, newAssessment);
     setAssessments(newArr);
   };
 
@@ -156,6 +174,7 @@ const Approval: NextPage = () => {
               key={assessment.assessmentId}
               assessment={assessment}
               setAssessmentScore={setAssessmentScore}
+              toggleFlag={toggleFlag}
             />
           ))}
         </Grid>

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -26,6 +26,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Togglebuttons from '../components/togglebuttons';
 import Tooltip from '@mui/material/Tooltip';
 import ProgressBar from '../components/progressbar';
+import Gradingbuttons from '../components/gradingbuttons';
 
 const Assessment: NextPage = () => {
   // create router object

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -132,7 +132,6 @@ const Assessment: NextPage = () => {
     typeof percentage == 'number'
       ? (newScore = percentage * assessment.maxPoints)
       : null;
-    console.log('points: ', newScore, ' of ', assessment.maxPoints);
     const newAssessment = {
       ...assessment,
       score: newScore,

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -26,7 +26,6 @@ import { v4 as uuidv4 } from 'uuid';
 import Togglebuttons from '../components/togglebuttons';
 import Tooltip from '@mui/material/Tooltip';
 import ProgressBar from '../components/progressbar';
-import Gradingbuttons from '../components/gradingbuttons';
 
 const Assessment: NextPage = () => {
   // create router object
@@ -127,8 +126,13 @@ const Assessment: NextPage = () => {
 
   const setAssessmentScore = (
     assessment: AssessmentType,
-    newScore: number | string
+    percentage: number | string
   ) => {
+    let newScore: number | string = percentage;
+    typeof percentage == 'number'
+      ? (newScore = percentage * assessment.maxPoints)
+      : null;
+    console.log('points: ', newScore, ' of ', assessment.maxPoints);
     const newAssessment = {
       ...assessment,
       score: newScore,

--- a/styles/Textbox.module.css
+++ b/styles/Textbox.module.css
@@ -40,3 +40,14 @@
 .pointboxAndFlag {
   display: flex;
 }
+
+.approvalTextboxCard {
+  display: flex;
+  flex-direction: column;
+}
+
+.approvalTextboxContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}


### PR DESCRIPTION
The `gradingbuttons` component is created with minimal features. When a grade is selected, the state is updated. The scores have to be of type `string` in order for the toggle choice to be marked. 

What is left:
- The calculation/weighting of scores. Scores are now 0-5
- Decide on scoring system for the approval page. We could either keep the `pointsbox`, but with options A-F or use the same scoring system as in the `textbox`.

![image](https://user-images.githubusercontent.com/44196526/162185955-fd2476c8-ae73-455d-a237-5ff993a18517.png)

