### PR TITLE
create menu with task titles

### DIFF
--- a/components/tasktitlebox.tsx
+++ b/components/tasktitlebox.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import MenuList from '@mui/material/MenuList';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import data from '../data/IT2810Høst2018.json';
+import Link from 'next/link';
+
+interface Tasktitleboxprops {
+  taskNumbers: number[];
+}
+
+const Tasktitlebox: React.FC<Tasktitleboxprops> = (
+  props: Tasktitleboxprops
+) => {
+  return (
+    <Paper sx={{ margin: '25px', marginLeft: '80px' }}>
+      <MenuList>
+        {props.taskNumbers.map((taskNum: number) => (
+          <MenuItem>
+            <ListItemIcon>{taskNum + 1}</ListItemIcon>
+            <Link
+              key={taskNum + 1}
+              href={{
+                pathname: '/assessment',
+                query: { task: taskNum + 1 },
+              }}
+              passHref
+            >
+              {
+                data.ext_inspera_candidates[0].result.ext_inspera_questions[
+                  taskNum
+                ].ext_inspera_questionTitle
+              }
+            </Link>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Paper>
+  );
+};
+
+export default Tasktitlebox;

--- a/pages/task.tsx
+++ b/pages/task.tsx
@@ -2,10 +2,11 @@ import { NextPage } from 'next';
 import mainStyles from '../styles/Main.module.css';
 import data from '../data/IT2810Høst2018.json';
 import Header from '../components/header';
-import { Button, Grid } from '@mui/material';
+import { Button } from '@mui/material';
 import Link from 'next/link';
 import { getAssessments } from '../functions/helpFunctions';
 import { useEffect, useState } from 'react';
+import Tasktitlebox from '../components/tasktitlebox';
 
 const Task: NextPage = () => {
   const totalTasks: number =
@@ -27,7 +28,8 @@ const Task: NextPage = () => {
     <div className={mainStyles.container}>
       <Header data={data} description={'Oversikt over alle oppgavene'} />
       <main style={{ display: 'flex', justifyContent: 'center' }}>
-        <Grid container gap={4} sx={{ maxWidth: 1230 }}>
+        <Tasktitlebox taskNumbers={taskNumbers} />
+        <div>
           {taskNumbers.map((taskNum: number) => {
             if (
               approvedAssessments != undefined &&
@@ -46,7 +48,7 @@ const Task: NextPage = () => {
                     color="success"
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ width: 73, height: 73, fontSize: 25, margin: '25px' }}
                   >
                     {taskNum + 1}
                   </Button>
@@ -69,7 +71,7 @@ const Task: NextPage = () => {
                     color="warning"
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ width: 73, height: 73, fontSize: 25, margin: '25px' }}
                   >
                     {taskNum + 1}
                   </Button>
@@ -88,7 +90,7 @@ const Task: NextPage = () => {
                   <Button
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ width: 73, height: 73, fontSize: 25, margin: '25px' }}
                   >
                     {taskNum + 1}
                   </Button>
@@ -96,7 +98,7 @@ const Task: NextPage = () => {
               );
             }
           })}
-        </Grid>
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
Created a basic menu on the `taskpage`with task number and the belonging title. The menu is clickable and will route to the `assessment page` of the current task.

It is missing the natural routing, but I will fix it once #115 is merged. This will make the PRs more cleaner so I do not have to pull and merge from different branches. 

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/44196526/162259198-870bd178-27a1-4b00-b6b6-01c9e9693e41.png">
