### PR TITLE
displaying task titles with extended buttons

### DIFF
--- a/functions/helpFunctions.tsx
+++ b/functions/helpFunctions.tsx
@@ -349,3 +349,9 @@ export function noRemainingAnswers(taskNum: number) {
     return true;
   }
 }
+
+export function getTaskTitle(taskNumber: number) {
+  return data.ext_inspera_candidates[0].result.ext_inspera_questions[
+  taskNumber - 1
+    ].ext_inspera_questionTitle;
+}

--- a/pages/task.tsx
+++ b/pages/task.tsx
@@ -1,10 +1,11 @@
 import { NextPage } from 'next';
 import mainStyles from '../styles/Main.module.css';
+import styles from '../styles/Task.module.css';
 import data from '../data/IT2810Høst2018.json';
 import Header from '../components/header';
-import { Button, Grid } from '@mui/material';
+import { Button } from '@mui/material';
 import Link from 'next/link';
-import { getAssessments, noRemainingAnswers } from '../functions/helpFunctions';
+import { getAssessments, getTaskTitle, noRemainingAnswers } from '../functions/helpFunctions';
 import { useEffect, useState } from 'react';
 
 const Task: NextPage = () => {
@@ -30,8 +31,7 @@ const Task: NextPage = () => {
         description={'Oversikt over alle oppgavene'}
         goBackPage=""
       />
-      <main style={{ display: 'flex', justifyContent: 'center' }}>
-        <Grid container gap={4} sx={{ maxWidth: 1230 }}>
+      <main className={styles.grid}>
           {taskNumbers.map((taskNum: number) => {
             if (
               approvedAssessments != undefined &&
@@ -50,9 +50,9 @@ const Task: NextPage = () => {
                     color="success"
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ height: 56, fontSize: 15, margin: 1 }}
                   >
-                    {taskNum + 1}
+                    {taskNum + 1}: {getTaskTitle(taskNum +1)}
                   </Button>
                 </Link>
               );
@@ -75,9 +75,9 @@ const Task: NextPage = () => {
                     color="warning"
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ height: 56, fontSize: 15, margin: 1 }}
                   >
-                    {taskNum + 1}
+                    {taskNum + 1}: {getTaskTitle(taskNum +1)}
                   </Button>
                 </Link>
               );
@@ -98,9 +98,9 @@ const Task: NextPage = () => {
                     color="warning"
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ height: 56, fontSize: 15, margin: 1 }}
                   >
-                    {taskNum + 1}
+                    {taskNum + 1}: {getTaskTitle(taskNum +1)}
                   </Button>
                 </Link>
               );
@@ -117,15 +117,14 @@ const Task: NextPage = () => {
                   <Button
                     key={taskNum + 1}
                     variant="contained"
-                    sx={{ width: 73, height: 73, fontSize: 25 }}
+                    sx={{ height: 56, fontSize: 15, margin: 1 }}
                   >
-                    {taskNum + 1}
+                    {taskNum + 1}: {getTaskTitle(taskNum +1)}
                   </Button>
                 </Link>
               );
             }
           })}
-        </Grid>
       </main>
     </div>
   );

--- a/styles/Task.module.css
+++ b/styles/Task.module.css
@@ -1,0 +1,7 @@
+
+.grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin: 2em 10em;
+}


### PR DESCRIPTION
Fix #55 
Just had to test it :) extend buttons to include task title. When the font is smaller, I think it works okay.
It is related to #128 , #126  and #121.

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/31897129/163730611-d75d7aba-3431-4381-b582-e7fcd363964b.png">
