### PR TITLE
fix typo and have a start value on progressbar

### DIFF
--- a/components/sortingbox.tsx
+++ b/components/sortingbox.tsx
@@ -24,7 +24,7 @@ const Sortingbox: React.FC<Sortingboxprops> = (props: Sortingboxprops) => {
     // { value: 'similarAnswers', label: 'Liknende besvarelser' },
     // { value: 'divergentAnswers', label: 'Divergerende besvarelser' },
     { value: 'length_hl', label: 'Lengde fra lengst til kortest' },
-    { value: 'length_lh', label: 'Lenge fra kortest til lengst' },
+    { value: 'length_lh', label: 'Lengde fra kortest til lengst' },
   ];
 
   const handleChange = (event: SelectChangeEvent) => {

--- a/pages/assessment.tsx
+++ b/pages/assessment.tsx
@@ -60,7 +60,7 @@ const Assessment: NextPage = () => {
 
   const [assessments, setAssessments] =
     useState<AssessmentType[]>(assessmentData);
-  const [progressPercentage, setProgressPercentage] = useState<number>(0);
+  const [progressPercentage, setProgressPercentage] = useState<number>(0.05);
 
   const startIndexBatch = currentPage * maxItemsPerPage - maxItemsPerPage;
   const endIndexBatch = currentPage * maxItemsPerPage;


### PR DESCRIPTION
synes det var litt nice at den ikke starter tom, da skjønner man ikke nødvendigvis hva det er.

![image](https://user-images.githubusercontent.com/31897129/164248921-0a0a5a78-ade7-4e9d-99bc-9f79416035f6.png)
